### PR TITLE
set_environment option

### DIFF
--- a/lib/capifony.rb
+++ b/lib/capifony.rb
@@ -207,6 +207,26 @@ namespace :symfony do
 
       stream "#{php_bin} #{latest_release}/symfony project:send-emails --message-limit=#{message_limit} --time-limit=#{time_limit} --env=#{symfony_env}"
     end
+    
+    desc 'Task to set all front controllers to a specific environment'
+    task :set_environment do
+      if (env = fetch(:symfony_env, nil)) && env != 'prod'
+        cmd   = []
+        apps  = fetch(:symfony_apps, ['frontend'])
+
+        # First application listed becomes index.php
+        if app = apps.shift
+          cmd << "cp #{release_path}/web/#{app}_#{env}.php #{release_path}/web/index.php"
+        end
+        
+        # All other apps are copied to their default controllers
+        for app in apps
+          cmd << "cp #{release_path}/web/#{app}_#{env}.php #{release_path}/web/#{app}.php"
+        end
+    
+        run cmd.join(';') if cmd.join(';')
+      end
+    end
   end
 
   namespace :plugin do


### PR DESCRIPTION
Hey Everzet.

I recently added the ability to set an application to an environment via a "symfony:project:set_environment" task.  Here is a use case for this:
- You have an environment called "staging"
- You have a cap deploy script called "staging.rb" 
- Any time someone accesses this application, you want them using the "staging" environment, but by default, index.php is prod.  As is backend.php, otherapp.php, etc.

If you do "set :symfony_env, 'staging'" in your staging.rb file, this will go ahead and rotate frontend_staging.php to index.php.  If you have more applications, just do "set :symfony_apps, ['frontend', 'backend', 'otherapp']".  The first string in the array becomes your index.php, while the others would copy backend_staging.php to backend.php and otherapp_staging.php to otherapp.php.   It automatically bypasses this process when :symfony_env is set to 'prod'.

I thin this is immensely useful.  It's been great for us in the case above.  I'd love it if you incorporated this into capifony!
