### PR TITLE
Windows compatibility for symfony1 "database:" namespace tasks

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -419,7 +419,7 @@ namespace :database do
   namespace :dump do
     desc "Dump remote database"
     task :remote do
-      filename  = "#{application}.remote_dump.#{Time.now.to_i}.sql.bz2"
+      filename  = "#{application}.remote_dump.#{Time.now.to_i}.sql.gz"
       file      = "/tmp/#{filename}"
       sqlfile   = "#{application}_dump.sql"
       config    = ""
@@ -430,62 +430,88 @@ namespace :database do
 
       case config['type']
       when 'mysql'
-        run "mysqldump -u#{config['user']} --password='#{config['pass']}' #{config['db']} | bzip2 -c > #{file}" do |ch, stream, data|
+        run "mysqldump -u#{config['user']} --password='#{config['pass']}' #{config['db']} | gzip -c > #{file}" do |ch, stream, data|
           puts data
         end
       when 'pgsql'
-        run "pg_dump -U #{config['user']} --password='#{config['pass']}' #{config['db']} | bzip2 -c > #{file}" do |ch, stream, data|
+        run "pg_dump -U #{config['user']} --password='#{config['pass']}' #{config['db']} | gzip -c > #{file}" do |ch, stream, data|
           puts data
         end
       end
 
-      `mkdir -p backups`
+      require "FileUtils"
+      FileUtils.mkdir_p("backups")
       get file, "backups/#{filename}"
-      `cd backups && ln -nfs #{filename} #{application}.remote_dump.latest.sql.bz2`
+      begin
+        FileUtils.ln_sf(filename, "backups/#{application}.remote_dump.latest.sql.gz")
+      rescue NotImplementedError # hack for windows which doesnt support symlinks
+        FileUtils.cp_r("backups/#{filename}", "backups/#{application}.remote_dump.latest.sql.gz")
+      end
       run "rm #{file}"
     end
 
     desc "Dump local database"
     task :local do
-      filename  = "#{application}.local_dump.#{Time.now.to_i}.sql.bz2"
+      filename  = "#{application}.local_dump.#{Time.now.to_i}.sql.gz"
+      tmpfile   = "backups/#{application}_dump_tmp.sql"
       file      = "backups/#{filename}"
       config    = load_database_config IO.read('config/databases.yml'), symfony_env_local
       sqlfile   = "#{application}_dump.sql"
 
-      `mkdir -p backups`
+      require "FileUtils"
+      FileUtils::mkdir_p("backups")
       case config['type']
       when 'mysql'
-        `mysqldump -u#{config['user']} --password='#{config['pass']}' #{config['db']} | bzip2 -c > #{file}`
+        `mysqldump -u#{config['user']} --password=\"#{config['pass']}\" #{config['db']} > #{tmpfile}`
       when 'pgsql'
-        `pg_dump -U #{config['user']} --password='#{config['pass']}' #{config['db']} | bzip2 -c > #{file}`
+        `pg_dump -U #{config['user']} --password=\"#{config['pass']}\" #{config['db']} > #{tmpfile}`
+      end
+      File.open(tmpfile, "r+") do |f|
+        gz = Zlib::GzipWriter.open(file)
+        while (line = f.gets)
+          gz << line
+        end
+        gz.flush
+        gz.close
       end
 
-      `cd backups && ln -nfs #{filename} #{application}.local_dump.latest.sql.bz2`
+      begin
+        FileUtils.ln_sf(filename, "backups/#{application}.local_dump.latest.sql.gz")
+      rescue NotImplementedError # hack for windows which doesnt support symlinks
+        FileUtils.cp_r("backups/#{filename}", "backups/#{application}.local_dump.latest.sql.gz")
+      end
+      FileUtils.rm(tmpfile)
     end
   end
 
   namespace :move do
     desc "Dump remote database, download it to local & populate here"
     task :to_local do
-      filename  = "#{application}.remote_dump.latest.sql.bz2"
+      filename  = "#{application}.remote_dump.latest.sql.gz"
       config    = load_database_config IO.read('config/databases.yml'), symfony_env_local
       sqlfile   = "#{application}_dump.sql"
 
       database.dump.remote
 
-      `bunzip2 -kc backups/#{filename} > backups/#{sqlfile}`
+      require "FileUtils"
+      f = File.new("backups/#{sqlfile}", "a+")
+      require "zlib"
+      gz = Zlib::GzipReader.new(File.open("backups/#{filename}", "r"))
+      f << gz.read
+      f.close
+      
       case config['type']
       when 'mysql'
-        `mysql -u#{config['user']} --password='#{config['pass']}' #{config['db']} < backups/#{sqlfile}`
+        `mysql -u#{config['user']} --password=\"#{config['pass']}\" #{config['db']} < backups/#{sqlfile}`
       when 'pgsql'
-        `psql -U #{config['user']} --password='#{config['pass']}' #{config['db']} < backups/#{sqlfile}`
+        `psql -U #{config['user']} --password=\"#{config['pass']}\" #{config['db']} < backups/#{sqlfile}`
       end
-      `rm backups/#{sqlfile}`
+      FileUtils.rm("backups/#{sqlfile}")
     end
 
     desc "Dump local database, load it to remote & populate there"
     task :to_remote do
-      filename  = "#{application}.local_dump.latest.sql.bz2"
+      filename  = "#{application}.local_dump.latest.sql.gz"
       file      = "backups/#{filename}"
       sqlfile   = "#{application}_dump.sql"
       config    = ""
@@ -493,7 +519,7 @@ namespace :database do
       database.dump.local
 
       upload(file, "/tmp/#{filename}", :via => :scp)
-      run "bunzip2 -kc /tmp/#{filename} > /tmp/#{sqlfile}"
+      run "gunzip -c /tmp/#{filename} > /tmp/#{sqlfile}"
 
       run "cat #{shared_path}/config/databases.yml" do |ch, st, data|
         config = load_database_config data, symfony_env_prod


### PR DESCRIPTION
I've made possible to use tasks from `database:` namespace of symfony1 lib possible on plain Windows.

There were a problem on Windows while using console tools like `mkdir -p` or missing symlinks on Windows (thus `ln` failing), so I wrapper up this operations with methods of `File` and `FileUtils` classes. 

I also had to wrap (un-)archiving of tranfered sql dumps and as I wanted to use just lib from ruby core and stdlib, I changed archiving method of transfered files from bzip2 to gzip (`Zlib` is stdlib, I haven't found any capable of (un-)bzipping ).

It's tested on plain virtualboxed Windows XP without cygwin, gnuwin or any other extensions.

I'm still a ruby-beginner so if I've missed some common practice, feel free to reject this request and please let me now, what to improve, I'll try my best:-)
