### PR TITLE
Added support for symfony 1.x lib in shared directory

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -19,6 +19,10 @@ set(:symfony_orm)     { guess_symfony_orm }
 # Symfony lib path
 set(:symfony_lib)     { guess_symfony_lib }
 
+# Shared symfony lib
+set :use_shared_symfony, false
+set :symfony_version, "1.4.11"
+
 def guess_symfony_orm
   databases = YAML::load(IO.read('config/databases.yml'))
 
@@ -128,6 +132,15 @@ namespace :symfony do
   desc "Clears the cache"
   task :cc do
     run "#{php_bin} #{latest_release}/symfony cache:clear"
+  end
+
+  desc "Creates symbolic link to symfony lib in shared"
+  task :create_lib_symlink do 
+    prompt_with_default(:version, symfony_version)
+    symlink_path = "#{latest_release}/lib/vendor/symfony"
+
+    run "if [ ! -d #{shared_path}/symfony-#{version} ]; then exit 1; fi;"
+    run "ln -nfs #{shared_path}/symfony-#{version} #{symlink_path};"
   end
 
   namespace :configure do
@@ -577,6 +590,33 @@ namespace :shared do
     task :to_remote do
       upload("web/uploads", "#{shared_path}/web", :via => :scp, :recursive => true)
     end
+  end
+
+  namespace :symfony do
+    desc "Downloads symfony framework to shared directory"
+    task :download do 
+      prompt_with_default(:version, symfony_version)
+  
+      run <<-CMD
+        if [ ! -d #{shared_path}/symfony-#{version} ]; then
+          wget -q http://www.symfony-project.org/get/symfony-#{version}.tgz -O- | tar -zxf - -C #{shared_path};
+        fi
+      CMD
+    end
+  end
+end
+
+# After setup
+after "deploy:setup" do
+  if use_shared_symfony
+    shared.symfony.download
+  end
+end
+
+# Before finalizing update
+before "deploy:finalize_update" do
+  if use_shared_symfony
+    symfony.create_lib_symlink
   end
 end
 


### PR DESCRIPTION
I prefer to link to symfony lib instead of keeping it in the repository. This commit introduces two new tasks:
- shared:symfony:download downloads symfony framework and stores it in shared
- symfony:create_lib_symlink creates a lib/vendor/symfony symlink to sources in shared

Download is called after deploy:setup to ensure that symfony is accessible during the deploy.

Symlink is created before finalizing the update as it is needed for every symfony task.

No task is automatically run unless use_shared_symfony is set to true. By default it's false.

As there is no symfony in the repository we cannot guess the version and have to ask it. Default is provided.
