### PR TITLE
Cache warmup and assets install configurable

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -21,6 +21,12 @@ set :dump_assetic_assets, false
 # Whether to run the bin/vendors script to update vendors
 set :update_vendors, false
 
+# Whether to run cache warmup 
+set :cache_warmup, true 
+
+# Assets install
+set :assets_install, true 
+
 # Dirs that need to remain the same between deploys (shared dirs)
 set :shared_children,     [log_path, web_path + "/uploads"]
 
@@ -258,8 +264,14 @@ after "deploy:finalize_update" do
     symfony.vendors.update                # 1. Update vendors
   end
 
-  symfony.cache.warmup                    # 2. Warmup clean cache
-  symfony.assets.install                  # 3. Publish bundle assets
+  if cache_warmup
+    symfony.cache.warmup                    # 2. Warmup clean cache
+  end
+  
+  if assets_install
+    symfony.assets.install                  # 3. Publish bundle assets
+  end
+
   if dump_assetic_assets
     symfony.assetic.dump                  # 4. Dump assetic assets
   end


### PR DESCRIPTION
Hey,

I think is useful to make this to commands configurable. We're getting a time out error when running the cache warmup command in the production making the deploy to roll back. And the assets install command is probably not needed for staging.

Thanks,

Carlos
