### PR TITLE
Fix a bug when using assetic.

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -258,8 +258,8 @@ after "deploy:finalize_update" do
     symfony.vendors.update                # 1. Update vendors
   end
 
-  symfony.cache.warmup                    # 2. Warmup clean cache
-  symfony.assets.install                  # 3. Publish bundle assets
+  symfony.assets.install                  # 2. Publish bundle assets
+  symfony.cache.warmup                    # 3. Warmup clean cache
   if dump_assetic_assets
     symfony.assetic.dump                  # 4. Dump assetic assets
   end


### PR DESCRIPTION
If you're using assetic, the cache:warmup will try to read your assets during a cache:warmup.

If they are not yet installed, you will get errors like:

  [ErrorException]  
  Warning: file_get_contents(xxx/web/bundles/demo/js/jquery-1.6.1.min.js): failed to open stream: No such file or directory in xxx/vendor/assetic/src/Assetic/Asset/FileAsset.php line 57

So I think that we should install the assets before the warming.
