### PR TITLE
In my tests, if you use assetic with the "?" character on filter, like th

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -126,7 +126,7 @@ namespace :symfony do
   namespace :assetic do
     desc "Dumps all assets to the filesystem"
     task :dump do
-      run "cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump #{web_path} --env=#{symfony_env_prod}"
+      run "cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump #{web_path} --env=#{symfony_env_prod} --no-debug"
     end
   end
 


### PR DESCRIPTION
In my tests, if you use assetic with the "?" character on filter, like this:

{% stylesheets 'my/css/*.css' filter='?yui_css' output='css/packed.css' %}
<link href="{{ asset_url }}" type="text/css" rel="stylesheet" />
{% endstylesheets %}

And then use the assetic:dump command without --no-debug, even in prod environment, assetic will ignore the filter.
