### PR TITLE
Separate propel build steps to reduce chances of memory limit issues.

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -399,7 +399,7 @@ namespace :symfony do
     task :build_classes do
       run "php #{latest_release}/symfony propel:build --model --env=#{symfony_env_prod}"
       run "php #{latest_release}/symfony propel:build --forms --env=#{symfony_env_prod}"
-      run "php #{latest_release}/symfony propel:build --filter --env=#{symfony_env_prod}"
+      run "php #{latest_release}/symfony propel:build --filters --env=#{symfony_env_prod}"
     end
 
     desc "Generate code & database based on your schema"


### PR DESCRIPTION
By building the propel model one class type at a type, we avoid a bug
with Phing and Propel, as well as making it much less likely for PHP
to run out of memory.
