### PR TITLE
Add vendors:reinstall and update vendors:update

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -142,7 +142,7 @@ namespace :symfony do
   namespace :vendors do
     desc "Runs the bin/vendors script to update the vendors"
     task :update do
-      run "cd #{latest_release} && #{php_bin} bin/vendors install --update"
+      run "cd #{latest_release} && #{php_bin} bin/vendors install"
     end
     task :reinstall do
       run "cd #{latest_release} && #{php_bin} bin/vendors install --reinstall"


### PR DESCRIPTION
I think that the default `vendors:update` command should call

```
bin/vendors install
```

and not

```
bin/vendors install --reinstall
```

The first one does not try to remove each vendor path before changing current HEAD (which is obviously much faster). I think it should be the default behavior.

Do you want to keep a `vendors:reinstall` command?
