### PR TITLE
Add symfony:init:acl task

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -281,6 +281,14 @@ namespace :symfony do
     end
   end
 
+  namespace :init do
+    desc "Mounts ACL tables in the database"
+    task :acl do
+      run "cd #{latest_release} && #{php_bin} #{symfony_console} init:acl --env=#{symfony_env_prod}"
+    end
+  end
+
+    
   namespace :propel do
     namespace :database do
       desc "Create the configured databases."


### PR DESCRIPTION
There's currently no way to init the acl tables after a first deploy.

This pull adds a task which calls init:acl.
