### PR TITLE
Fix migration version matching

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -98,7 +98,7 @@ namespace :deploy do
   task :migrate do
     currentVersion = nil
     run "cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status --env=#{symfony_env_prod}" do |ch, stream, out|
-      if stream == :out and out =~ /Current Version:[^$]+\(([0-9]+)\)/
+      if stream == :out and out =~ /Current Version:[^$]+\(([\w]+)\)/
         currentVersion = Regexp.last_match(1)
       end
       if stream == :out and out =~ /Current Version:\s*0\s*$/


### PR DESCRIPTION
The regex used to find the migration version is too restrictive and will only match numeric versions. Doctrine migrations are not restricted to only numbers, but the migrations task will fail on non-numeric but legal version names. To fix this, I've loosened the regex to accept any "word" character (letter, number, underscore).
