### PR TITLE
Enable try_sudo mode for ./symfony cc to allow remove files like twig cache created with a chmod 644 and stored in the sf_cache_dir

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -132,7 +132,7 @@ namespace :symfony do
 
   desc "Clears the cache"
   task :cc do
-    run "cd #{latest_release} && #{php_bin} ./symfony cache:clear"
+    run "cd #{latest_release} && #{try_sudo} #{php_bin} ./symfony cache:clear"
     run "chmod -R g+w #{latest_release}/cache"
   end
 


### PR DESCRIPTION
Enable try_sudo mode for ./symfony cc to allow remove files like twig cache created with a chmod 644 and stored in the sf_cache_dir

See https://github.com/fabpot/Twig/blob/master/lib/Twig/Environment.php#L1052
