### PR TITLE
If set :update_vendors, false - we have Fatal error: require_once():bootstrap.php.cache

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -161,6 +161,13 @@ namespace :symfony do
       run "cd #{latest_release} && #{php_bin} bin/vendors update"
     end
   end
+    
+  namespace :bootstrap do
+    desc "Runs the bin/build_bootstrap whithout upgrade the vendors"
+    task :build do
+      run "cd #{latest_release} && #{php_bin} bin/build_bootstrap"
+    end
+  end
 
   namespace :composer do
     desc "Runs composer install to install vendors from composer.lock file"
@@ -336,6 +343,11 @@ after "deploy:finalize_update" do
     end
   elsif use_composer
     symfony.composer.install
+  else
+    # share the children first (to get the vendor symlink)
+    deploy.share_childs
+    vendors_mode.chomp # To remove trailing whiteline
+    symfony.bootstrap.build
   end
 
   if assets_install


### PR DESCRIPTION
For this setting - add symfony.bootstrap.build, and in bin directory create file build_bootstrap:

---
# !/usr/bin/env php

<?php
set_time_limit(0);

$rootDir = dirname(**DIR**);
$vendorDir = $rootDir.'/vendor';
// php on windows can't use the shebang line from system()
$interpreter = defined('PHP_WINDOWS_VERSION_BUILD') ? 'php.exe' : '';

// Update the bootstrap files
system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php'), escapeshellarg($rootDir)));
