### PR TITLE
Added database tasks to symfony2.rb

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -45,6 +45,140 @@ set :asset_children,      [web_path + "/css", web_path + "/images", web_path + "
 set :model_manager, "doctrine"
 # Or: `propel`
 
+
+def load_database_config(data, env)
+  parameters = YAML::load(data)
+
+  parameters['parameters']
+end
+
+namespace :database do
+  namespace :dump do
+    desc "Dump remote database"
+    task :remote do
+      filename  = "#{application}.remote_dump.#{Time.now.to_i}.sql.gz"
+      file      = "/tmp/#{filename}"
+      sqlfile   = "#{application}_dump.sql"
+      config    = ""
+
+      run "cat #{current_path}/app/config/parameters.yml" do |ch, st, data|
+        config = load_database_config data, symfony_env_prod
+      end
+
+      case config['database_driver']
+      when 'pdo_mysql'
+        run "mysqldump -u#{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} | gzip -c > #{file}" do |ch, stream, data|
+          puts data
+        end
+      when 'pdo_pgsql'
+        run "pg_dump -U #{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} | gzip -c > #{file}" do |ch, stream, data|
+          puts data
+        end
+      end
+
+      require "FileUtils"
+      FileUtils.mkdir_p("backups")
+      get file, "backups/#{filename}"
+      begin
+        FileUtils.ln_sf(filename, "backups/#{application}.remote_dump.latest.sql.gz")
+      rescue NotImplementedError # hack for windows which doesnt support symlinks
+        FileUtils.cp_r("backups/#{filename}", "backups/#{application}.remote_dump.latest.sql.gz")
+      end
+      run "rm #{file}"
+    end
+
+    desc "Dump local database"
+    task :local do
+      filename  = "#{application}.local_dump.#{Time.now.to_i}.sql.gz"
+      tmpfile   = "backups/#{application}_dump_tmp.sql"
+      file      = "backups/#{filename}"
+      config    = load_database_config IO.read('app/config/parameters.yml'), symfony_env_local
+      sqlfile   = "#{application}_dump.sql"
+
+      require "FileUtils"
+      FileUtils::mkdir_p("backups")
+      case config['database_driver']
+      when 'pdo_mysql'
+        `mysqldump -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
+      when 'pdo_pgsql'
+        `pg_dump -U #{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
+      end
+      File.open(tmpfile, "r+") do |f|
+        gz = Zlib::GzipWriter.open(file)
+        while (line = f.gets)
+          gz << line
+        end
+        gz.flush
+        gz.close
+      end
+
+      begin
+        FileUtils.ln_sf(filename, "backups/#{application}.local_dump.latest.sql.gz")
+      rescue NotImplementedError # hack for windows which doesnt support symlinks
+        FileUtils.cp_r("backups/#{filename}", "backups/#{application}.local_dump.latest.sql.gz")
+      end
+      FileUtils.rm(tmpfile)
+    end
+  end
+
+  namespace :move do
+    desc "Dump remote database, download it to local & populate here"
+    task :to_local do
+      filename  = "#{application}.remote_dump.latest.sql.gz"
+      config    = load_database_config IO.read('app/config/parameters.yml'), symfony_env_local
+      sqlfile   = "#{application}_dump.sql"
+
+      database.dump.remote
+
+      require "FileUtils"
+      f = File.new("backups/#{sqlfile}", "a+")
+      require "zlib"
+      gz = Zlib::GzipReader.new(File.open("backups/#{filename}", "r"))
+      f << gz.read
+      f.close
+
+      case config['database_driver']
+      when 'pdo_mysql'
+        `mysql -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} < backups/#{sqlfile}`
+      when 'pdo_pgsql'
+        `psql -U #{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} < backups/#{sqlfile}`
+      end
+      FileUtils.rm("backups/#{sqlfile}")
+    end
+
+    desc "Dump local database, load it to remote & populate there"
+    task :to_remote do
+      filename  = "#{application}.local_dump.latest.sql.gz"
+      file      = "backups/#{filename}"
+      sqlfile   = "#{application}_dump.sql"
+      config    = ""
+
+      database.dump.local
+
+      upload(file, "/tmp/#{filename}", :via => :scp)
+      run "gunzip -c /tmp/#{filename} > /tmp/#{sqlfile}"
+
+      run "cat #{shared_path}/config/databases.yml" do |ch, st, data|
+        config = load_database_config data, symfony_env_prod
+      end
+
+      case config['database_driver']
+      when 'pdo_mysql'
+        run "mysql -u#{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} < /tmp/#{sqlfile}" do |ch, stream, data|
+          puts data
+        end
+      when 'pdo_pgsql'
+        run "psql -U #{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} < /tmp/#{sqlfile}" do |ch, stream, data|
+          puts data
+        end
+      end
+
+      run "rm /tmp/#{filename}"
+      run "rm /tmp/#{sqlfile}"
+    end
+  end
+end
+
 namespace :deploy do
   desc "Symlink static directories and static files that need to remain between deployments."
   task :share_childs do


### PR DESCRIPTION
The following database tasks were implemented, based on symfony1.rb:
- cap database:dump:local
- cap database:dump:remote
- cap database:move:to_local
- cap database:move:to_remote
