### PR TITLE
Changes all require 'FileUtils' to lower case.

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -79,7 +79,7 @@ namespace :database do
         end
       end
 
-      require "FileUtils"
+      require "fileutils"
       FileUtils.mkdir_p("backups")
       get file, "backups/#{filename}"
       begin
@@ -98,7 +98,7 @@ namespace :database do
       config    = load_database_config IO.read('app/config/parameters.yml'), symfony_env_local
       sqlfile   = "#{application}_dump.sql"
 
-      require "FileUtils"
+      require "fileutils"
       FileUtils::mkdir_p("backups")
       case config['database_driver']
       when 'pdo_mysql'
@@ -133,7 +133,7 @@ namespace :database do
 
       database.dump.remote
 
-      require "FileUtils"
+      require "fileutils"
       f = File.new("backups/#{sqlfile}", "a+")
       require "zlib"
       gz = Zlib::GzipReader.new(File.open("backups/#{filename}", "r"))


### PR DESCRIPTION
Related to [pull request #109](https://github.com/everzet/capifony/pull/109), except this changes the case of the require "FileUtils" statements in lib/symfony2.rb.

This resolves the issue I posted on StackOverflow, [Capifony database functions fail with `require': cannot load such file — FileUtils (LoadError)](http://stackoverflow.com/questions/10108485/capifony-database-functions-fail-with-require-cannot-load-such-file-fileut).  
