### PR TITLE
Removes --password flag from pg_dump

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -451,7 +451,7 @@ namespace :database do
           puts data
         end
       when 'pgsql'
-        run "pg_dump -U #{config['user']} --password='#{config['pass']}' #{config['db']} | gzip -c > #{file}" do |ch, stream, data|
+        run "pg_dump -U #{config['user']} #{config['db']} | gzip -c > #{file}" do |ch, stream, data|
           puts data
         end
       end
@@ -481,7 +481,7 @@ namespace :database do
       when 'mysql'
         `mysqldump -u#{config['user']} --password=\"#{config['pass']}\" #{config['db']} > #{tmpfile}`
       when 'pgsql'
-        `pg_dump -U #{config['user']} --password=\"#{config['pass']}\" #{config['db']} > #{tmpfile}`
+        `pg_dump -U #{config['user']} #{config['db']} > #{tmpfile}`
       end
       File.open(tmpfile, "r+") do |f|
         gz = Zlib::GzipWriter.open(file)

--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -74,7 +74,7 @@ namespace :database do
           puts data
         end
       when 'pdo_pgsql'
-        run "pg_dump -U #{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} | gzip -c > #{file}" do |ch, stream, data|
+        run "pg_dump -U #{config['database_user']} #{config['database_name']} | gzip -c > #{file}" do |ch, stream, data|
           puts data
         end
       end
@@ -104,7 +104,7 @@ namespace :database do
       when 'pdo_mysql'
         `mysqldump -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
       when 'pdo_pgsql'
-        `pg_dump -U #{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
+        `pg_dump -U #{config['database_user']} #{config['database_name']} > #{tmpfile}`
       end
       File.open(tmpfile, "r+") do |f|
         gz = Zlib::GzipWriter.open(file)


### PR DESCRIPTION
The --password flag for pg_dump doesn't accept a password as a parameter like mysql_dump does.  cap database:dump:local and cap database:dump:remote fail in their current state.  Removing the --password flag allows pg_dump to succeed, but only if there is a ~/.pgpass file in place (see [http://www.postgresql.org/docs/9.1/static/libpq-pgpass.html](http://www.postgresql.org/docs/9.1/static/libpq-pgpass.html)).  That means a ~/.pgpass file will need to exist on the local dev box and each box where cap will deploy.

The ~/.pgpass requirement should probably be enforced with a warning message if the file doesn't exist, but that's well beyond my current ruby capabilities.
