### PR TITLE
bin/build_bootstrap doesn't exist in Symfony2

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -298,13 +298,6 @@ namespace :symfony do
       run "cd #{latest_release} && #{php_bin} #{symfony_vendors} update"
     end
   end
-    
-  namespace :bootstrap do
-    desc "Runs the bin/build_bootstrap whithout upgrade the vendors"
-    task :build do
-      run "cd #{latest_release} && #{php_bin} bin/build_bootstrap"
-    end
-  end
 
   namespace :composer do
     desc "Runs composer install to install vendors from composer.lock file"
@@ -480,11 +473,6 @@ after "deploy:finalize_update" do
     end
   elsif use_composer
     symfony.composer.install
-  else
-    # share the children first (to get the vendor symlink)
-    deploy.share_childs
-    vendors_mode.chomp # To remove trailing whiteline
-    symfony.bootstrap.build
   end
 
   if assets_install


### PR DESCRIPTION
bin/build_bootstrap doesn't exist in Symfony2 anymore since a long time (and it has been removed for a good reason).

Currently, if you try to deploy a new project with a clean Symfony2 install and a default capifony installation, it won't work. That is bad (in my opinion).

(See also comments in https://github.com/everzet/capifony/pull/90)
