### PR TITLE
Add task for setting folder permissions (see: http://goo.gl/L916e)

### DIFF
--- a/lib/symfony2.rb
+++ b/lib/symfony2.rb
@@ -183,6 +183,16 @@ namespace :database do
 end
 
 namespace :deploy do
+  desc "Sets folder permissions/ACL (see: http://goo.gl/L916e)"
+  task :permissions, :roles => :app do
+    if shared_children
+      shared_children << app_path + "/cache"
+      run "cd #{latest_release} && sudo chmod -R g+w #{shared_children.join(' ')}"
+      run "cd #{latest_release} && sudo setfacl -R -m u:www-data:rwx -m u:`whoami`:rwx #{shared_children.join(' ')}"
+      run "cd #{latest_release} && sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx #{shared_children.join(' ')}"
+    end
+  end
+
   desc "Symlink static directories and static files that need to remain between deployments."
   task :share_childs do
     if shared_children


### PR DESCRIPTION
This should really go in `deploy:setup` but setup is not a namespace. I use like this:

``` ruby
after "deploy" do
  deploy.permissions
end
```
