### PR TITLE
Make database:dump and database:move tasks work for a large project

### DIFF
--- a/lib/symfony1.rb
+++ b/lib/symfony1.rb
@@ -495,7 +495,7 @@ namespace :database do
   namespace :dump do
     desc "Dump remote database"
     task :remote do
-      filename  = "#{application}.remote_dump.#{Time.now.to_i}.sql.gz"
+      filename  = "#{application}.remote_dump.#{Time.now.strftime("%Y-%m-%d_%H-%M-%S")}.sql.gz"
       file      = "/tmp/#{filename}"
       sqlfile   = "#{application}_dump.sql"
       config    = ""
@@ -522,7 +522,7 @@ namespace :database do
 
     desc "Dump local database"
     task :local do
-      filename  = "#{application}.local_dump.#{Time.now.to_i}.sql.gz"
+      filename  = "#{application}.local_dump.#{Time.now.strftime("%Y-%m-%d_%H-%M-%S")}.sql.gz"
       tmpfile   = "backups/#{application}_dump_tmp.sql"
       file      = "backups/#{filename}"
       config    = load_database_config IO.read('config/databases.yml'), symfony_env_local


### PR DESCRIPTION
Hi,

Here are a few improvements I had to make to `database:dump` and `database:move` tasks to make them work on a large symfony1 project I'm working on:
- Add support to multiple connections in database.yml
- Add full symfony "configuration cascade" support when reading database.yml
- Support optional host and port in database.yml
- Drop and recreate database after a database:move so that no old table persists
- Decrease memory print of database:move:to_local so that it becomes usable for a large database (using ruby methods to gunzip a large file reaches memory limit too quickly).
- Improve dump files time stamp readability
