### PR TITLE
Make composer.phar install|update use verbose output

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -56,7 +56,7 @@ namespace :symfony do
         symfony.composer.get
       end
 
-      run "cd #{latest_release} && #{php_bin} composer.phar install"
+      run "cd #{latest_release} && #{php_bin} composer.phar install -v"
     end
 
     desc "Runs composer to update vendors, and composer.lock file"
@@ -65,7 +65,7 @@ namespace :symfony do
         symfony.composer.get
       end
 
-      run "cd #{latest_release} && #{php_bin} composer.phar update"
+      run "cd #{latest_release} && #{php_bin} composer.phar update -v"
     end
   end
 


### PR DESCRIPTION
When there is an error in the Composer output (say, from a script that Compose executes), it is hard to debug because there is no error message. Adding the `-v` flag helps with this.
