### PR TITLE
Fixed database tasks for postgresql

### DIFF
--- a/lib/symfony2/database.rb
+++ b/lib/symfony2/database.rb
@@ -20,7 +20,7 @@ namespace :database do
           puts data
         end
       when "pdo_pgsql", "pgsql"
-        run "pg_dump -U #{config['database_user']} #{config['database_name']} | gzip -c > #{file}" do |ch, stream, data|
+        run "pg_dump -U #{config['database_user']} #{config['database_name']} --clean | gzip -c > #{file}" do |ch, stream, data|
           puts data
         end
       end
@@ -49,7 +49,7 @@ namespace :database do
       when "pdo_mysql", "mysql"
         `mysqldump -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
       when "pdo_pgsql", "pgsql"
-        `pg_dump -U #{config['database_user']} #{config['database_name']} > #{tmpfile}`
+        `pg_dump -U #{config['database_user']} #{config['database_name']} --clean > #{tmpfile}`
       end
 
       File.open(tmpfile, "r+") do |f|
@@ -88,7 +88,7 @@ namespace :database do
       when "pdo_mysql", "mysql"
         `mysql -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} < backups/#{sqlfile}`
       when "pdo_pgsql", "pgsql"
-        `psql -U #{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} < backups/#{sqlfile}`
+        `psql -U #{config['database_user']} #{config['database_name']} < backups/#{sqlfile}`
       end
       FileUtils.rm("backups/#{sqlfile}")
     end
@@ -115,7 +115,7 @@ namespace :database do
           puts data
         end
       when "pdo_pgsql", "pgsql"
-        run "psql -U #{config['database_user']} --password='#{config['database_password']}' #{config['database_name']} < /tmp/#{sqlfile}" do |ch, stream, data|
+        run "psql -U #{config['database_user']} #{config['database_name']} < /tmp/#{sqlfile}" do |ch, stream, data|
           puts data
         end
       end


### PR DESCRIPTION
Hey, 

I've finally forced myself to make this PR that solves 2 issues while using capifony with postgresql database

1# fix
Added --clean parameter so dump will include DROP IF EXISTS statement

reference:
http://www.postgresql.org/docs/9.1/static/app-pgdump.html

This is required for command cap database:move:to_local to work if we already have populated database

2# fix
Also I removed invalid --password argument from psql command
Postgresql doesnt allow to pass password as argument, only option is to type it manualy or use pgpass file

reference
http://www.postgresql.org/docs/current/static/libpq-pgpass.html

Let me know if that's ok
