### PR TITLE
Use `--no-scripts` during `composer install/update` to avoid useless/duplicate processing.

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -84,7 +84,7 @@ namespace :symfony do
 
       pretty_print "--> Installing Composer dependencies"
 
-      run "cd #{latest_release} && #{php_bin} composer.phar install -v"
+      run "cd #{latest_release} && #{php_bin} composer.phar install --no-scripts --verbose"
       puts_ok
     end
 
@@ -96,7 +96,7 @@ namespace :symfony do
 
       pretty_print "--> Updating Composer dependencies"
 
-      run "cd #{latest_release} && #{php_bin} composer.phar update -v"
+      run "cd #{latest_release} && #{php_bin} composer.phar update --no-scripts --verbose"
       puts_ok
     end
   end


### PR DESCRIPTION
I also expanded `-v` to `--verbose` because it looks better next to `--no-scripts` :blush:
