### PR TITLE
fix elsif synthax (else if -> elsif)

### DIFF
--- a/lib/symfony2/deploy.rb
+++ b/lib/symfony2/deploy.rb
@@ -29,7 +29,7 @@ namespace :deploy do
 
         if use_sudo
           run sprintf(methods[permission_method], dirs.join(' '))
-        else if permission_method == :chown
+        elsif permission_method == :chown
           puts "    You can't use chown method without sudoing"
         else
           dirs.each do |dir|


### PR DESCRIPTION
This is the cause of syntax error in my environments (Mac OS 10.7.4 Ruby 1.9.3-p194).

```
/Users/gde/.rvm/gems/ruby-1.9.3-p194/gems/capistrano-2.12.0/lib/capistrano/configuration/loading.rb:93:in `instance_eval': /Users/gde/.rvm/gems/ruby-1.9.3-p194/gems/capifony-2.1.10/lib/symfony2/deploy.rb:45: syntax error, unexpected keyword_else, expecting keyword_end (SyntaxError)
/Users/gde/.rvm/gems/ruby-1.9.3-p194/gems/capifony-2.1.10/lib/symfony2/deploy.rb:135: syntax error, unexpected $end, expecting keyword_end
```
