### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ lot easier.
 
 ## What's next? ##
 
-Read the [capifony documentation](http://everzet.github.com/capifony/)
+Read the [capifony documentation](http://capifony.org/)
 
 
 ## Contributors ##


### PR DESCRIPTION
The current link leads to http://everzet.github.com/capifony/ which has broken CSS. I changed it to point to http://capifony.org/
