### PR TITLE
Fix running doctrine migrations with allocated PTY

### DIFF
--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -59,7 +59,7 @@ namespace :symfony do
       desc "Executes a migration to a specified version or the latest available version"
       task :migrate, :roles => :app, :except => { :no_release => true } do
         currentVersion = nil
-        run "cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status --env=#{symfony_env_prod}", :once => true do |ch, stream, out|
+        run "cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}", :once => true do |ch, stream, out|
           if stream == :out and out =~ /Current Version:[^$]+\(([\w]+)\)/
             currentVersion = Regexp.last_match(1)
           end


### PR DESCRIPTION
If a pty is allocated for the ssh session running the "status" command,
the output might contain ANSI color codes which break the regex that
tries to detect the current database schema version. To avoid this, we
have to use the --no-ansi option to disable the colors.
