### PR TITLE
Fix doctrine:migrations:migrate#currentVersion returning NIL

### DIFF
--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -60,7 +60,7 @@ namespace :symfony do
       task :migrate, :roles => :app, :except => { :no_release => true } do
         currentVersion = nil
         run "cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}", :once => true do |ch, stream, out|
-          if stream == :out and out =~ /Current Version:[^$]+\(([\w]+)\)/
+          if stream == :out and out =~ /Current Version:.+\(([\w]+)\)/
             currentVersion = Regexp.last_match(1)
           end
           if stream == :out and out =~ /Current Version:\s*0\s*$/


### PR DESCRIPTION
The pattern `[^$]+`failed to match any of the string past "Current Version:", while `.+` matches only the characters preceding the version number.

```
$ ruby -v
ruby 1.8.7 (2012-02-08 patchlevel 358) [i686-linux]
$ gem -v
1.6.2
$ cap --version
Capistrano v2.12.0

capifony-2.1.11
```

My deployments kept failing until I tested the regular exhibit locally & found the original pattern failed.
