### PR TITLE
.first instead of .last as the selected gem for symfony1/symfony2

### DIFF
--- a/bin/capifony
+++ b/bin/capifony
@@ -54,7 +54,7 @@ if symfony_version == 2
     "Capfile" => unindent(<<-FILE),
       load 'deploy' if respond_to?(:namespace) # cap2 differentiator
       Dir['vendor/**/Resources/recipes/*.rb'].each { |bundle| load(bundle) }
-      load Gem.find_files('symfony2.rb').last.to_s
+      load Gem.find_files('symfony2.rb').first.to_s
       load '#{symfony_app_path}/config/deploy'
     FILE
 
@@ -86,7 +86,7 @@ else
     "Capfile" => unindent(<<-FILE),
       load 'deploy' if respond_to?(:namespace) # cap2 differentiator
       Dir['plugins/*/lib/recipes/*.rb'].each { |plugin| load(plugin) }
-      load Gem.find_files('symfony1.rb').last.to_s
+      load Gem.find_files('symfony1.rb').first.to_s
       load 'config/deploy'
     FILE
 


### PR DESCRIPTION
refers to [this issue](https://github.com/everzet/capifony/issues/190)

be careful, I'm not sure if this works on every system...sure it works on ubuntu 12.04 with ruby 1.9.3. I hope that Gem::find_files works in the same way on every system.

[the official docs](http://apidock.com/ruby/v1_9_3_125/Gem/find_files/class) do not mention the order anywhere.
