### PR TITLE
Tweaked the way 'assets_version' value is updated

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -25,7 +25,7 @@ namespace :symfony do
   namespace :assets do
     desc "Updates assets version (in config.yml)"
     task :update_version, :roles => :app, :except => { :no_release => true } do
-       run "sed -i 's/\\(assets_version: \\)\\([a-zA-Z0-9_]*\\)\\(.*\\)$/\\1 \"#{real_revision[0,7]}\"\\3/g' #{latest_release}/#{app_path}/config/config.yml"
+       run "#{try_sudo} sed -i 's/\\(assets_version: \\)\\([a-zA-Z0-9_]*\\)\\(.*\\)$/\\1 \"#{real_revision[0,7]}\"\\3/g' #{latest_release}/#{app_path}/config/config.yml"
     end
 
     desc "Installs bundle's assets"


### PR DESCRIPTION
I've made three changes:

1) Tweak: in my opinion, the full commit hash is too long to use it as asset version. Using the short hash notation is better and equally effective. Therefore, I've replaced `#{real_revision}` by `#{real_revision[0,7]}`

2) Fix: in my server, the replacement caused an error because the new assets_version value is not enclosed with quotes. Therefore I've replaced `#{real_revision[0,7]}` by `\"#{real_revision[0,7]}\"`

3) Fix: I configure my assets_version as follows:

```
# app/config/config.yml
framework:
    # …
    templating: { engines: ['twig'], assets_version:'xxx' }
```

Instead of:

```
# app/config/config.yml
framework:
    # …
    templating:
        engines:        ['twig']
        assets_version: 'xxx'
```

In my opinion, the current regexp is too restrictive because it only works well with the second configuration. Therefore, I've replaced it:

Original: `sed -i 's/\\(assets_version: \\)\\(.*\\)$/\\1 \"#{real_revision[0,7]}\"/g'`
Proposal: `sed -i 's/\\(assets_version: \\)\\([a-zA-Z0-9_]*\\)\\(.*\\)$/\\1 \"#{real_revision[0,7]}\"\\3/g'`

This new regexp works well with both configurations. However, the new regexp forces the value of `assets_version` option to be composed only of letters, numbers and `_`. In some application this may also be too restrictive.
