### PR TITLE
prevented an infinite loop in symfony:composer:update

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -134,9 +134,7 @@ namespace :symfony do
 
     desc "Runs composer to update vendors, and composer.lock file"
     task :update, :roles => :app, :except => { :no_release => true } do
-      if composer_bin
-        symfony.composer.update
-      else
+      if !composer_bin
         symfony.composer.get
         composer_bin = "#{php_bin} composer.phar"
       end


### PR DESCRIPTION
Not quite sure what the purpose of the `update` call was here - suspect it may have been intended to be a `composer self-update` call? - but an infinite loop was happening in the case where the `:composer_bin` option is set.
