### PR TITLE
cd command not found when composer self-update

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -106,7 +106,7 @@ namespace :symfony do
       if !remote_file_exists?("#{latest_release}/composer.phar")
         run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}'"
       else
-        run "#{try_sudo} cd #{latest_release} && #{php_bin} composer.phar self-update"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} composer.phar self-update'"
       end
       puts_ok
     end


### PR DESCRIPTION
'cd command not found' when composer tries to self-update, this is fixed in other commands by adding the sh -c around it ... i think it has something to do with that it is using a wrong shell when doing sudo
