### PR TITLE
Fixed chmod deploy permissions to be compatible with filesystems other than just OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 README
 *.gem
+*.idea

--- a/lib/symfony2/deploy.rb
+++ b/lib/symfony2/deploy.rb
@@ -19,10 +19,7 @@ namespace :deploy do
       end
 
       methods = {
-        :chmod => [
-          "chmod +a \"#{user} allow delete,write,append,file_inherit,directory_inherit\" %s",
-          "chmod +a \"#{webserver_user} allow delete,write,append,file_inherit,directory_inherit\" %s"
-        ],
+        :chmod => ["chmod -R 0777 %s"],
         :acl   => [
           "setfacl -R -m u:#{user}:rwx -m u:#{webserver_user}:rwx %s",
           "setfacl -dR -m u:#{user}:rwx -m u:#{webserver_user}:rwx %s"


### PR DESCRIPTION
The current behavior of using `chmod +a "user perms..." %s` doesn't work on any of my web servers. They are a combination of Ubuntu and Centos, which I'd say is fairly common. 

Apparently the +a syntax only applies to OSX operating systems ([source](http://stackoverflow.com/questions/8768417/how-to-enable-chmod-a-in-centos))
