### PR TITLE
Updated composer "copy_vendor" snippets to be compatible with capifony 2.2.x

### DIFF
--- a/cookbook/speeding-up-deploy.markdown
+++ b/cookbook/speeding-up-deploy.markdown
@@ -22,10 +22,10 @@ namespace :symfony do
   desc "Copy vendors from previous release"
   task :copy_vendors, :except => { :no_release => true } do
     if Capistrano::CLI.ui.agree("Do you want to copy last release vendor dir then do composer install ?: (y/N)")
-      pretty_print "--> Copying vendors from previous release"
+      capifony_pretty_print "--> Copying vendors from previous release"
 
       run "cp -a #{previous_release}/vendor #{latest_release}/"
-      puts_ok
+      capifony_puts_ok
     end
   end
 end
@@ -48,10 +48,10 @@ before 'symfony:composer:update', 'composer:copy_vendors'
 
 namespace :composer do
   task :copy_vendors, :except => { :no_release => true } do
-    pretty_print "--> Copy vendor file from previous release"
+    capifony_pretty_print "--> Copy vendor file from previous release"
 
     run "vendorDir=#{current_path}/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir #{latest_release}/vendor; fi;"
-    puts_ok
+    capifony_puts_ok
   end
 end
 {% endhighlight %}


### PR DESCRIPTION
Updated composer "copy_vendor" snippets to be compatible with capifony
2.2.x
