### PR TITLE
Added a new cookbook page - Deployment in clustered machines

### DIFF
--- a/cookbook/deployment-in-clustered-machines.markdown
+++ b/cookbook/deployment-in-clustered-machines.markdown
@@ -1,0 +1,26 @@
+---
+layout: cookbook
+title: Deployment in clustered machines
+---
+
+When you need to perform the same deploy in more than one machine at the same time,
+you can use the `HOSTS` parameter as follows:
+
+### Setup the machines
+
+Before you can use any of the Capistrano deployment tasks with your project, you will need to
+make sure all of your servers have been prepared, for that run:
+
+	cap HOSTS="machine1.domain, machine2.domain" deploy:setup
+
+
+### Deploy
+
+ The rest of the task must run same as a normal deploy, but always using the `HOSTS` parameter
+
+	cap HOSTS="machine1.domain, machine2.domain" deploy
+
+
+### Multistage deploy
+
+	cap HOSTS="machine1.domain, machine2.domain" stage_name deploy

--- a/index.markdown
+++ b/index.markdown
@@ -291,6 +291,8 @@ extension](cookbook/using-the-multistage-extension.html)
 
 [Working with databases](cookbook/working-with-databases.html)
 
+[Deployment in clustered machines](cookbook/deployment-in-clustered-machines.html)
+
 <hr />
 
 ## Known Issues


### PR DESCRIPTION
In the page I explain how to make a deploy in more than one machine at the same time and linked it in the index page, at the end of the cookbook section
