### PR TITLE
Created a new variable to allow execute set_permissions automatically

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -103,6 +103,9 @@ module Capifony
         # Method used to set permissions (:chmod, :acl, or :chown)
         set :permission_method,     false
 
+        # Execute set permissions
+        set :use_set_permissions,   false
+
         # Model manager: (doctrine, propel)
         set :model_manager,         "doctrine"
 
@@ -212,6 +215,10 @@ module Capifony
           end
 
           symfony.bootstrap.build
+
+          if use_set_permissions
+            symfony.deploy.set_permissions
+          end
 
           if model_manager == "propel"
             symfony.propel.build.model


### PR DESCRIPTION
> This is a proposal of change, if finally accepted I'll change the necessary documentation. 

I Created a new param `use_set_permissions` false by default, to set if want to execute the set_permissions task automatically.

If the variable is set to true execute `set_permissions`  running the validators of the task (checking the existence of the necessary variables)
