### PR TITLE
Documented the deploy:cleanup as a note

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -66,6 +66,10 @@ In this case, on every `cap deploy`, capifony will:
 * copy the source code, pulled from git, into the release path
 * run deployment hooks (`cache:warmup`, `cc`, etc.)
 
+> NOTE : By default capifony don't clean the releases. For execute the clean realeses
+> task is necessary to set the `keep_releases` param and add to the deploy.rb file 
+> the task after end the deploy,  like this: `after "deploy", "deploy:cleanup"`
+
 If you don't want to clone the whole repository on every deploy, you can set the
 `:deploy_via` parameter:
 


### PR DESCRIPTION
I think that the `keep_realeses` param can be misleading, because you think that just with this param capifony will clean the old releases.

I just add the way to realize them in the documentation, although  it could be interesting modify the code for run the cleanup task when the keep_releases is not null. If you think that make sense, i interested in try to make the change (to practice ruby)
