### PR TITLE
If the param keep_releases is loaded automatically clean the old release...

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -261,6 +261,9 @@ module Capifony
         end
 
         after "deploy:create_symlink" do
+          if keep_releases
+            deploy.cleanup
+          end
           puts "--> Successfully deployed!".green
         end
       end


### PR DESCRIPTION
> This is a proposal of change, if finally accepted I'll change the necessary documentation. 

When the `keep_releases` param has loaded, automatically clean the old releases at the end of the deploy.
