### PR TITLE
deploy:migrate primary restriction is not cascaded

### DIFF
--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -78,7 +78,7 @@ namespace :symfony do
 
     namespace :migrations do
       desc "Executes a migration to a specified version or the latest available version"
-      task :migrate, :roles => :app, :except => { :no_release => true } do
+      task :migrate, :roles => :app, :only => { :primary => true }, :except => { :no_release => true } do
         currentVersion = nil
         run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}'", :once => true do |ch, stream, out|
           if stream == :out and out =~ /Current Version:.+\(([\w]+)\)/


### PR DESCRIPTION
deploy:migrate calls symfony:doctrine:migrations:migrate and it's executed on every machine
