### PR TITLE
extended fallback code for symlinks on file systems that don't support them

### DIFF
--- a/lib/symfony1/database.rb
+++ b/lib/symfony1/database.rb
@@ -23,7 +23,7 @@ namespace :database do
       get file, "backups/#{filename}"
       begin
         FileUtils.ln_sf(filename, "backups/#{application}.remote_dump.latest.sql.gz")
-      rescue NotImplementedError # hack for windows which doesnt support symlinks
+      rescue Exception # fallback for file systems that don't support symlinks
         FileUtils.cp_r("backups/#{filename}", "backups/#{application}.remote_dump.latest.sql.gz")
       end
       run "#{try_sudo} rm #{file}"
@@ -54,7 +54,7 @@ namespace :database do
 
       begin
         FileUtils.ln_sf(filename, "backups/#{application}.local_dump.latest.sql.gz")
-      rescue NotImplementedError # hack for windows which doesnt support symlinks
+      rescue Exception # fallback for file systems that don't support symlinks
         FileUtils.cp_r("backups/#{filename}", "backups/#{application}.local_dump.latest.sql.gz")
       end
       FileUtils.rm(tmpfile)
@@ -69,7 +69,7 @@ namespace :database do
 
       begin
         zipped_file_path  = `readlink -f backups/#{application}.remote_dump.latest.sql.gz`.chop  # gunzip does not work with a symlink
-      rescue NotImplementedError # hack for windows which doesnt support symlinks
+      rescue Exception # fallback for file systems that don't support symlinks
         zipped_file_path  = "backups/#{application}.remote_dump.latest.sql.gz"
       end
       unzipped_file_path   = "backups/#{application}_dump.sql"

--- a/lib/symfony2/database.rb
+++ b/lib/symfony2/database.rb
@@ -30,7 +30,7 @@ namespace :database do
       get file, "backups/#{filename}"
       begin
         FileUtils.ln_sf(filename, "backups/#{application}.#{env}_dump.latest.sql.gz")
-      rescue NotImplementedError # hack for windows which doesnt support symlinks
+      rescue Exception # fallback for file systems that don't support symlinks
         FileUtils.cp_r("backups/#{filename}", "backups/#{application}.#{env}_dump.latest.sql.gz")
       end
       run "#{try_sudo} rm #{file}"
@@ -63,7 +63,7 @@ namespace :database do
 
       begin
         FileUtils.ln_sf(filename, "backups/#{application}.local_dump.latest.sql.gz")
-      rescue NotImplementedError # hack for windows which doesnt support symlinks
+      rescue Exception # fallback for file systems that don't support symlinks
         FileUtils.cp_r("backups/#{filename}", "backups/#{application}.local_dump.latest.sql.gz")
       end
       FileUtils.rm(tmpfile)


### PR DESCRIPTION
I've encountered problems using the `database:` namespaced tasks on a filesystem that doesn't support symlinks.

Specifically i'm using capifony in a virtualbox shared folder mounted inside a linux guest os. (see this https://www.virtualbox.org/ticket/10085)
Using the `database:dump:remote` task resulted in a `symlink: Read-only file system` error.

I've extended the fallback code used for Windows to a more general `Exception` rather than a `NotImplementedError` in order to cover the issue.

I'm not a ruby developer so please be patient. :)
