### PR TITLE
Clear controllers should only run on the app role

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -192,7 +192,7 @@ namespace :symfony do
 
   namespace :project do
     desc "Clears all non production environment controllers"
-    task :clear_controllers do
+    task :clear_controllers, :roles => :app, :except => { :no_release => true } do
       capifony_pretty_print "--> Clear controllers"
 
       command = "#{try_sudo} sh -c 'cd #{latest_release} && rm -f"


### PR DESCRIPTION
We've got a fairly complicated role setup in our application.  Having the clear_controllers run on every server is causing us to have to override this command in our own setup.  

Shouldn't this command only run on `:app`?
