### PR TITLE
Do not update composer [Closes #309]

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -5,7 +5,7 @@ namespace :symfony do
 
     stream "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{task_arguments} --env=#{symfony_env_prod}'"
   end
-    
+
 
   namespace :logs do
     [:tail, :tail_dev].each do |action|
@@ -116,17 +116,10 @@ namespace :symfony do
     end
 
     desc "Updates composer"
-    task :self_update, :roles => :app, :except => { :no_release => true } do
-      capifony_pretty_print "--> Updating Composer"
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} self-update'"
-      capifony_puts_ok
-    end
 
     desc "Runs composer to install vendors from composer.lock file"
     task :install, :roles => :app, :except => { :no_release => true } do
-      if composer_bin
-        symfony.composer.self_update
-      else
+      if !composer_bin
         symfony.composer.get
         set :composer_bin, "#{php_bin} composer.phar"
       end
@@ -138,9 +131,7 @@ namespace :symfony do
 
     desc "Runs composer to update vendors, and composer.lock file"
     task :update, :roles => :app, :except => { :no_release => true } do
-      if composer_bin
-        symfony.composer.self_update
-      else
+      if !composer_bin
         symfony.composer.get
         set :composer_bin, "#{php_bin} composer.phar"
       end
@@ -152,9 +143,7 @@ namespace :symfony do
 
     desc "Dumps an optimized autoloader"
     task :dump_autoload, :roles => :app, :except => { :no_release => true } do
-      if composer_bin
-        symfony.composer.self_update
-      else
+      if !composer_bin
         symfony.composer.get
         set :composer_bin, "#{php_bin} composer.phar"
       end

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -149,7 +149,6 @@ describe "Capifony::Symfony2 - symfony" do
   end
 
   it "defines symfony:composer tasks" do
-    @configuration.find_task('symfony:composer:self_update').should_not == nil
     @configuration.find_task('symfony:composer:install').should_not == nil
     @configuration.find_task('symfony:composer:update').should_not == nil
     @configuration.find_task('symfony:composer:dump_autoload').should_not == nil
@@ -174,7 +173,6 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer self-update\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer update --no-scripts --verbose --prefer-dist\'') }
   end
 
@@ -231,7 +229,6 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer self-update\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer install --no-scripts --verbose --prefer-dist\'') }
   end
 
@@ -260,7 +257,6 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer self-update\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer dump-autoload --optimize\'') }
   end
 


### PR DESCRIPTION
- I guess in most cases it is unwanted: When I specify :composer_bin, I want to use _this_ copy, not another one
- It doesn't make much sense, because if there is a single new commit to composer, it is nearly the
  same operation as `composer_get`. So a user _must_ keep their composer copy always up to date to avoid
  the unwanted update.
- It may have unwanted side effects, especially when `composer.phar` is shared between user.
- it may not be possible, if the user is not allowed to write to `composer.phar`
