### PR TITLE
Compatibility to Capistrano 2.14.1

### DIFF
--- a/capifony.gemspec
+++ b/capifony.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.bindir       = "bin"
   spec.executables << "capifony"
 
-  spec.add_dependency 'capistrano', "~> 2.13.5"
+  spec.add_dependency 'capistrano', ">= 2.13.5","<= 2.14.1"
   spec.add_dependency 'colored', ">= 1.2.0"
   spec.add_dependency 'inifile', ">= 2.0.2"
   spec.add_dependency 'capistrano-maintenance', '0.0.2'

--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -69,11 +69,9 @@ namespace :symfony do
       end
     end
 
-    namespace :fixtures do
-      desc "Load data fixtures"
-      task :load, :roles => :app, :except => { :no_release => true } do
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load --env=#{symfony_env_prod}'", :once => true
-      end
+    desc "Load data fixtures"
+    task :load_fixtures, :roles => :app, :except => { :no_release => true } do
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load --env=#{symfony_env_prod}'", :once => true
     end
 
     namespace :migrations do


### PR DESCRIPTION
My ubuntu system always wants to install `capistrano-2.14.1` and I always must uninstall it to get capifony working again, so I thought I have a look which changes are required to make it work with the newer version. Unfortunately I had to rename a task, because `load` as a taskname leads to an error. In this PR I renamed `doctrine:fixtures:load` to `doctrine:load_fixtures`, because it was the only `fixtures`-task anyway. I think the (new) name of the task, or even this PR as a whole is open for discussion now :smile: 
- 2.13.5 still works
- Tests passes (what also means, that there were no tests for this task :relaxed:)
