### PR TITLE
Added :doctrine_em configuration option for custom Doctrine entity manager

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -112,6 +112,9 @@ module Capifony
         # Model manager: (doctrine, propel)
         set :model_manager,         "doctrine"
 
+        # Doctrine custom entity manager
+        set :doctrine_em,           false
+
         # Symfony2 version
         set(:symfony_version)       { guess_symfony_version }
 
@@ -188,6 +191,22 @@ module Capifony
                 $error = true
               end
             end
+          end
+        end
+
+        [
+          "symfony:doctrine:cache:clear_metadata",
+          "symfony:doctrine:cache:clear_query",
+          "symfony:doctrine:cache:clear_result",
+          "symfony:doctrine:schema:create",
+          "symfony:doctrine:schema:drop",
+          "symfony:doctrine:schema:update",
+          "symfony:doctrine:load_fixtures",
+          "symfony:doctrine:migrations:migrate",
+          "symfony:doctrine:migrations:status",
+        ].each do |action|
+          before action do
+            set :doctrine_em_flag, doctrine_em ? " --em=#{doctrine_em}" : ""
           end
         end
 

--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -5,7 +5,7 @@ namespace :symfony do
       task :clear_metadata, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Clearing Doctrine metadata cache"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-metadata --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-metadata --env=#{symfony_env_prod}#{doctrine_em_flag}'"
         capifony_puts_ok
       end
 
@@ -13,7 +13,7 @@ namespace :symfony do
       task :clear_query, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Clearing Doctrine query cache"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-query --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-query --env=#{symfony_env_prod}#{doctrine_em_flag}'"
         capifony_puts_ok
       end
 
@@ -21,7 +21,7 @@ namespace :symfony do
       task :clear_result, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Clearing Doctrine result cache"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-result --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-result --env=#{symfony_env_prod}#{doctrine_em_flag}'"
         capifony_puts_ok
       end
     end
@@ -51,7 +51,7 @@ namespace :symfony do
       task :create, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Creating schema"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:create --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:create --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
         capifony_puts_ok
       end
 
@@ -60,7 +60,7 @@ namespace :symfony do
         capifony_pretty_print "--> Droping schema"
 
         if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to drop #{symfony_env_prod}'s database schema? (y/N)")
-          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:drop --force --env=#{symfony_env_prod}'", :once => true
+          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:drop --force --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
         end
         capifony_puts_ok
       end
@@ -69,21 +69,21 @@ namespace :symfony do
       task :update, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Updating schema"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:update --force --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:update --force --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
         capifony_puts_ok
       end
     end
 
     desc "Load data fixtures"
     task :load_fixtures, :roles => :app, :except => { :no_release => true } do
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load --env=#{symfony_env_prod}'", :once => true
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
     end
 
     namespace :migrations do
       desc "Executes a migration to a specified version or the latest available version"
       task :migrate, :roles => :app, :only => { :primary => true }, :except => { :no_release => true } do
         currentVersion = nil
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}'", :once => true do |ch, stream, out|
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true do |ch, stream, out|
           if stream == :out and out =~ /Current Version:.+\(([\w]+)\)/
             currentVersion = Regexp.last_match(1)
           end
@@ -99,18 +99,18 @@ namespace :symfony do
 
         on_rollback {
           if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to migrate #{symfony_env_prod}'s database back to version #{currentVersion}? (y/N)")
-            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate #{currentVersion} --env=#{symfony_env_prod} --no-interaction'", :once => true
+            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate #{currentVersion} --env=#{symfony_env_prod} --no-interaction#{doctrine_em_flag}'", :once => true
           end
         }
 
         if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to migrate #{symfony_env_prod}'s database? (y/N)")
-          run "#{try_sudo} sh -c ' cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate --env=#{symfony_env_prod} --no-interaction'", :once => true
+          run "#{try_sudo} sh -c ' cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate --env=#{symfony_env_prod} --no-interaction#{doctrine_em_flag}'", :once => true
         end
       end
 
       desc "Views the status of a set of migrations"
       task :status, :roles => :app, :except => { :no_release => true } do
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
       end
     end
 

--- a/spec/capifony_symfony2_doctrine_spec.rb
+++ b/spec/capifony_symfony2_doctrine_spec.rb
@@ -99,6 +99,18 @@ describe "Capifony::Symfony2 - doctrine" do
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod\'') }
   end
 
+  it "defines symfony:doctrine:load_fixtures task" do
+    @configuration.find_task('symfony:doctrine:load_fixtures').should_not == nil
+  end
+
+  context "when running symfony:doctrine:load_fixtures" do
+    before do
+      @configuration.find_and_execute_task('symfony:doctrine:load_fixtures')
+    end
+
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod\'') }
+  end
+
   it "defines symfony:doctrine:migrations tasks" do
     @configuration.find_task('symfony:doctrine:migrations:migrate').should_not == nil
     @configuration.find_task('symfony:doctrine:migrations:status').should_not == nil
@@ -171,4 +183,29 @@ describe "Capifony::Symfony2 - doctrine" do
 
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console init:acl --env=prod\'') }
   end
+
+  context "when running symfony:doctrine:* with custom entity manager" do
+    before do
+      @configuration.set :doctrine_em, 'custom_em'
+
+      @configuration.find_and_execute_task('symfony:doctrine:cache:clear_metadata')
+      @configuration.find_and_execute_task('symfony:doctrine:cache:clear_query')
+      @configuration.find_and_execute_task('symfony:doctrine:cache:clear_result')
+      @configuration.find_and_execute_task('symfony:doctrine:schema:create')
+      @configuration.find_and_execute_task('symfony:doctrine:schema:drop')
+      @configuration.find_and_execute_task('symfony:doctrine:schema:update')
+      @configuration.find_and_execute_task('symfony:doctrine:load_fixtures')
+      @configuration.find_and_execute_task('symfony:doctrine:migrations:status')
+    end
+
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:create --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:drop --force --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:migrations:status --env=prod --em=custom_em\'') }
+  end
+
 end


### PR DESCRIPTION
This implements the suggested configuration option in #321. It's worth noting that I'm a ruby novice, so this may not be the most polished solution. Suggestions or improvements from more seasoned ruby/capistrano devs would be welcome!

**Update:** per @willdurand's suggestion, simplified down to one em config option that would apply to all relevant doctrine commands
