### PR TITLE
Add PHP options "detect_unicode" and "allow_url_fopen" to composer calls

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -96,6 +96,7 @@ namespace :symfony do
 
   namespace :composer do
     desc "Gets composer and installs it"
+    set :composer_php_bin, "#{php_bin} -d detect_unicode=Off -d allow_url_fopen=On"
     task :get, :roles => :app, :except => { :no_release => true } do
       if remote_file_exists?("#{previous_release}/composer.phar")
         capifony_pretty_print "--> Copying Composer from previous release"
@@ -106,11 +107,11 @@ namespace :symfony do
       if !remote_file_exists?("#{latest_release}/composer.phar")
         capifony_pretty_print "--> Downloading Composer"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{composer_php_bin}'"
       else
         capifony_pretty_print "--> Updating Composer"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} composer.phar self-update'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_php_bin} composer.phar self-update'"
       end
       capifony_puts_ok
     end
@@ -121,7 +122,7 @@ namespace :symfony do
     task :install, :roles => :app, :except => { :no_release => true } do
       if !composer_bin
         symfony.composer.get
-        set :composer_bin, "#{php_bin} composer.phar"
+        set :composer_bin, "#{composer_php_bin} composer.phar"
       end
 
       capifony_pretty_print "--> Installing Composer dependencies"
@@ -133,7 +134,7 @@ namespace :symfony do
     task :update, :roles => :app, :except => { :no_release => true } do
       if !composer_bin
         symfony.composer.get
-        set :composer_bin, "#{php_bin} composer.phar"
+        set :composer_bin, "#{composer_php_bin} composer.phar"
       end
 
       capifony_pretty_print "--> Updating Composer dependencies"
@@ -145,7 +146,7 @@ namespace :symfony do
     task :dump_autoload, :roles => :app, :except => { :no_release => true } do
       if !composer_bin
         symfony.composer.get
-        set :composer_bin, "#{php_bin} composer.phar"
+        set :composer_bin, "#{composer_php_bin} composer.phar"
       end
 
       capifony_pretty_print "--> Dumping an optimized autoloader"

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -161,8 +161,8 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar update --no-scripts --verbose --prefer-dist\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar update --no-scripts --verbose --prefer-dist\'') }
   end
 
   context "when running symfony:composer:update with a given composer_bin" do
@@ -172,7 +172,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer update --no-scripts --verbose --prefer-dist\'') }
   end
 
@@ -193,9 +193,9 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --verbose --prefer-dist\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar self-update\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar install --no-scripts --verbose --prefer-dist\'') }
   end
 
   context "when running symfony:composer:install without any existing composer.phar in the previous release" do
@@ -206,9 +206,9 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --verbose --prefer-dist\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar self-update\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar install --no-scripts --verbose --prefer-dist\'') }
   end
 
   context "when running symfony:composer:install" do
@@ -217,8 +217,8 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --verbose --prefer-dist\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar install --no-scripts --verbose --prefer-dist\'') }
   end
 
   context "when running symfony:composer:install with a given composer_bin" do
@@ -228,7 +228,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer install --no-scripts --verbose --prefer-dist\'') }
   end
 
@@ -246,8 +246,8 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar dump-autoload --optimize\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php -d detect_unicode=Off -d allow_url_fopen=On composer.phar dump-autoload --optimize\'') }
   end
 
   context "when running symfony:composer:dump_autoload with a given composer_bin" do
@@ -256,7 +256,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -d detect_unicode=Off -d allow_url_fopen=On\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer dump-autoload --optimize\'') }
   end
 


### PR DESCRIPTION
Composer requires the option "detect_unicode" disabled and the option
"allow_url_fopen" enabled. These options can be passed at execution time
to PHP.
See: https://github.com/josegonzalez/homebrew-php/pull/83

Does this make sense for capifony?
