### PR TITLE
Fix Copying Composer from previous release

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -97,11 +97,6 @@ namespace :symfony do
   namespace :composer do
     desc "Gets composer and installs it"
     task :get, :roles => :app, :except => { :no_release => true } do
-      if remote_file_exists?("#{current_path}/composer.phar")
-        capifony_pretty_print "--> Copying Composer from previous release"
-        run "#{try_sudo} sh -c 'cp #{current_path}/composer.phar #{latest_release}/'"
-        capifony_puts_ok
-      end
 
       if !remote_file_exists?("#{latest_release}/composer.phar")
         capifony_pretty_print "--> Downloading Composer"


### PR DESCRIPTION
Before:

```
*** [err :: server] cp: `/home/domain/releases/20130204152210/composer.phar' and `/home/domain/releases/20130204152210/composer.phar' are the same file
*** [deploy:update_code] rolling back
```

After change work fine.
