### PR TITLE
More composer control

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -52,7 +52,11 @@ module Capifony
         # If set to false, it will use the bin/vendors script
         set :use_composer,          false
 
-		set :keep_latest_composer_bin, false
+		# Define if the composer binary must be copied from the previous release
+		set :keep_previous_composer_bin, false
+
+		# Define if the composer binary must be updated
+		set :composer_selfupdate,	true
 
         # Path to composer binary
         # If set to false, Capifony will download/install composer

--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -97,7 +97,7 @@ namespace :symfony do
   namespace :composer do
     desc "Gets composer and installs it"
     task :get, :roles => :app, :except => { :no_release => true } do
-      if keep_latest_composer_bin && remote_file_exists?("#{previous_release}/composer.phar")
+      if keep_previous_composer_bin && remote_file_exists?("#{previous_release}/composer.phar")
         capifony_pretty_print "--> Copying Composer from previous release"
         run "#{try_sudo} sh -c 'cp #{previous_release}/composer.phar #{latest_release}/'"
         capifony_puts_ok
@@ -107,7 +107,9 @@ namespace :symfony do
         capifony_pretty_print "--> Downloading Composer"
 
         run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}'"
-      else
+	  end
+
+	  if composer_selfupdate
         capifony_pretty_print "--> Updating Composer"
 
         run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} composer.phar self-update'"


### PR DESCRIPTION
Hello

The goal of my contribution is to keep control of the composer version.
I added two options:
- :keep_previous_composer_bin : if composer is versioned in my repository, the current behavior is to always copy the previous binary in my latest release. So, if I update my composer version, it will never be pushed.
- :composer_selfupdate : this option is mandatory if I want to update composer myself.
