### PR TITLE
Update assets_version before installing assets

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -250,12 +250,12 @@ module Capifony
             symfony.composer.dump_autoload
           end
 
-          if assets_install
-            symfony.assets.install          # Publish bundle assets
-          end
-
           if update_assets_version
             symfony.assets.update_version   # Update `assets_version`
+          end
+
+          if assets_install
+            symfony.assets.install          # Publish bundle assets
           end
 
           if cache_warmup


### PR DESCRIPTION
Installing assets has the side effect of creating the production cache without the assets_version being written too first.
