### PR TITLE
[RTM] Install/Update Vendors via Copy

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -56,6 +56,9 @@ module Capifony
         # If set to false, it will use the bin/vendors script
         set :use_composer,          false
 
+        # Whether to use composer to install vendors to a local temp directory.
+        set :use_composer_tmp,     false
+
         # Path to composer binary
         # If set to false, Capifony will download/install composer
         set :composer_bin,          false
@@ -267,7 +270,7 @@ module Capifony
         end
 
         after "deploy:finalize_update" do
-          if use_composer
+          if use_composer && !use_composer_tmp
             if update_vendors
               symfony.composer.update
             else
@@ -294,7 +297,7 @@ module Capifony
             symfony.propel.build.model
           end
 
-          if use_composer
+          if use_composer && !use_composer_tmp
             symfony.composer.dump_autoload
           end
 

--- a/lib/capistrano/recipes/deploy/strategy/capifony_copy_local.rb
+++ b/lib/capistrano/recipes/deploy/strategy/capifony_copy_local.rb
@@ -1,0 +1,25 @@
+require 'capistrano/recipes/deploy/strategy/copy'
+require 'fileutils'
+require 'capifony_symfony2'
+
+module Capistrano
+  module Deploy
+    module Strategy
+      class CapifonyCopyLocal < Copy
+        print "--> Using Copy Local Strategy\n"
+        # Deploy
+        def deploy!
+          copy_cache ? run_copy_cache_strategy : run_copy_strategy
+          create_revision_file
+          $temp_destination = destination  # Make temp location avaliable globally.
+          symfony.composer.install
+          symfony.bootstrap.build
+          compress_repository
+          distribute!
+        ensure
+          rollback_changes
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Description: Override copy strategy to allow vendors to be installed locally before the code is zipped and pushed to remote server. This reduces the dependencies required on the remote server and solves the issue with private [repository access](https://github.com/everzet/capifony/pull/340/commits).

Symfony2 and composer only.

Bug fix: no
Feature addition: yes
Fixture addition: no
Backwards compatibility break: no
Tests: pass
Fixes the following tickets: #241

Todo:
- [x] Ideally I would like to extend the capistrano copy strategy with a capifony copy strategy. I couldn't figure out how to do this nicely so I have overloaded the copy strategy deploy method for now.
- [x] Not entirely sure where this should belong in terms of folder structure, should I mirror the capistrano directory structure for strategies?
- [x] Need to avoid new implementation of composer methods.

``` ruby
set :deploy_via,  :capifony_copy_local
set :use_composer, true
set :use_composer_tmp, true
```
