### PR TITLE
BugFix when deploy symfony 1.4 with user_sudo = true

### DIFF
--- a/lib/symfony1/symfony.rb
+++ b/lib/symfony1/symfony.rb
@@ -17,7 +17,7 @@ namespace :symfony do
 
   desc "Clears the cache"
   task :cc do
-    run "#{try_sudo} sh -c 'cd #{latest_release} && #{try_sudo} #{php_bin} ./symfony cache:clear'"
+    run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} ./symfony cache:clear'"
     run "#{try_sudo} chmod -R g+w #{latest_release}/cache"
   end
 


### PR DESCRIPTION
This is a bugFix in the thask :cc (Clear the cache)

When i try to deploy a project with user_sudo = true, the line 

```
 run "#{try_sudo} sh -c 'cd #{latest_release} && #{try_sudo} #{php_bin} ./symfony cache:clear'"
```

in clear cache fail, because the 2do #{try_sudo} crash the command line to the call with sudo.
