### PR TITLE
Add 'symfony_debug' setting to toggle --no-debug on console commands

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -29,6 +29,9 @@ module Capifony
 
         # Symfony console bin
         set :symfony_console,       app_path + "/console"
+        
+        # Symfony debug flag for console commands
+        set :symfony_debug,         false
 
         # Symfony log path
         set :log_path,              app_path + "/logs"
@@ -148,6 +151,16 @@ module Capifony
 
         def remote_command_exists?(command)
           'true' == capture("if [ -x \"$(which #{command})\" ]; then echo 'true'; fi").strip
+        end
+        
+        def console_options
+          console_options = "--env=#{symfony_env_prod}"
+          
+          if !symfony_debug
+             console_options += " --no-debug"
+          end
+          
+          return console_options
         end
 
         STDOUT.sync

--- a/lib/symfony2/doctrine.rb
+++ b/lib/symfony2/doctrine.rb
@@ -11,7 +11,7 @@ namespace :symfony do
             flush_option = ""
         end
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-metadata --env=#{symfony_env_prod}#{doctrine_em_flag}#{flush_option}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-metadata #{console_options}#{doctrine_em_flag}#{flush_option}'"
         capifony_puts_ok
       end
 
@@ -25,7 +25,7 @@ namespace :symfony do
             flush_option = ""
         end
         
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-query --env=#{symfony_env_prod}#{doctrine_em_flag}#{flush_option}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-query #{console_options}#{doctrine_em_flag}#{flush_option}'"
         capifony_puts_ok
       end
 
@@ -39,7 +39,7 @@ namespace :symfony do
             flush_option = ""
         end
         
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-result --env=#{symfony_env_prod}#{doctrine_em_flag}#{flush_option}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:cache:clear-result #{console_options}#{doctrine_em_flag}#{flush_option}'"
         capifony_puts_ok
       end
     end
@@ -50,7 +50,7 @@ namespace :symfony do
         capifony_pretty_print "--> Dropping databases"
 
         if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to drop #{symfony_env_prod}'s database? (y/N)")
-          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:database:drop --force --env=#{symfony_env_prod}'", :once => true
+          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:database:drop --force #{console_options}'", :once => true
         end
         capifony_puts_ok
       end
@@ -59,7 +59,7 @@ namespace :symfony do
       task :create, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Creating databases"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:database:create --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:database:create #{console_options}'", :once => true
         capifony_puts_ok
       end
     end
@@ -69,7 +69,7 @@ namespace :symfony do
       task :create, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Creating schema"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:create --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:create #{console_options}#{doctrine_em_flag}'", :once => true
         capifony_puts_ok
       end
 
@@ -78,7 +78,7 @@ namespace :symfony do
         capifony_pretty_print "--> Droping schema"
 
         if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to drop #{symfony_env_prod}'s database schema? (y/N)")
-          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:drop --force --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
+          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:drop --force #{console_options}#{doctrine_em_flag}'", :once => true
         end
         capifony_puts_ok
       end
@@ -87,21 +87,21 @@ namespace :symfony do
       task :update, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Updating schema"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:update --force --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:schema:update --force #{console_options}#{doctrine_em_flag}'", :once => true
         capifony_puts_ok
       end
     end
 
     desc "Load data fixtures"
     task :load_fixtures, :roles => :app, :except => { :no_release => true } do
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:fixtures:load #{console_options}#{doctrine_em_flag}'", :once => true
     end
 
     namespace :migrations do
       desc "Executes a migration to a specified version or the latest available version"
       task :migrate, :roles => :app, :only => { :primary => true }, :except => { :no_release => true } do
         currentVersion = nil
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true do |ch, stream, out|
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} --no-ansi doctrine:migrations:status #{console_options}#{doctrine_em_flag}'", :once => true do |ch, stream, out|
           if stream == :out and out =~ /Current Version:.+\(([\w]+)\)/
             currentVersion = Regexp.last_match(1)
           end
@@ -117,18 +117,18 @@ namespace :symfony do
 
         on_rollback {
           if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to migrate #{symfony_env_prod}'s database back to version #{currentVersion}? (y/N)")
-            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate #{currentVersion} --env=#{symfony_env_prod} --no-interaction#{doctrine_em_flag}'", :once => true
+            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate #{currentVersion} #{console_options} --no-interaction#{doctrine_em_flag}'", :once => true
           end
         }
 
         if !interactive_mode || Capistrano::CLI.ui.agree("Do you really want to migrate #{symfony_env_prod}'s database? (y/N)")
-          run "#{try_sudo} sh -c ' cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate --env=#{symfony_env_prod} --no-interaction#{doctrine_em_flag}'", :once => true
+          run "#{try_sudo} sh -c ' cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:migrate #{console_options} --no-interaction#{doctrine_em_flag}'", :once => true
         end
       end
 
       desc "Views the status of a set of migrations"
       task :status, :roles => :app, :except => { :no_release => true } do
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status --env=#{symfony_env_prod}#{doctrine_em_flag}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:migrations:status #{console_options}#{doctrine_em_flag}'", :once => true
       end
     end
 
@@ -139,7 +139,7 @@ namespace :symfony do
           task action, :roles => :app, :except => { :no_release => true } do
             capifony_pretty_print "--> Executing MongoDB schema #{action.to_s}"
 
-            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:mongodb:schema:#{action.to_s} --env=#{symfony_env_prod}'", :once => true
+            run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:mongodb:schema:#{action.to_s} #{console_options}'", :once => true
             capifony_puts_ok
           end
         end
@@ -150,7 +150,7 @@ namespace :symfony do
             task action, :roles => :app do
               capifony_pretty_print "--> Executing MongoDB indexes #{action.to_s}"
 
-              run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:mongodb:schema:#{action.to_s} --index --env=#{symfony_env_prod}'", :once => true
+              run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} doctrine:mongodb:schema:#{action.to_s} --index #{console_options}'", :once => true
               capifony_puts_ok
             end
           end
@@ -163,7 +163,7 @@ namespace :symfony do
       task :acl, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Mounting Doctrine ACL tables"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} init:acl --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} init:acl #{console_options}'", :once => true
         capifony_puts_ok
       end
     end

--- a/lib/symfony2/propel.rb
+++ b/lib/symfony2/propel.rb
@@ -11,7 +11,7 @@ namespace :symfony do
             capifony_pretty_print "--> Dropping databases"
           end
 
-          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:database:#{action.to_s} --env=#{symfony_env_prod}'", :once => true
+          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:database:#{action.to_s} #{console_options}'", :once => true
           capifony_puts_ok
         end
       end
@@ -27,7 +27,7 @@ namespace :symfony do
 
         capifony_pretty_print "--> Generating Propel classes"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} #{console_options}'"
         capifony_puts_ok
       end
 
@@ -40,7 +40,7 @@ namespace :symfony do
 
         capifony_pretty_print "--> Generating Propel SQL"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} #{console_options}'"
         capifony_puts_ok
       end
 
@@ -53,7 +53,7 @@ namespace :symfony do
 
         capifony_pretty_print "--> Inserting Propel SQL"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} --force --env=#{symfony_env_prod}'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{command} --force #{console_options}'", :once => true
         capifony_puts_ok
       end
 
@@ -61,18 +61,18 @@ namespace :symfony do
       task :all_and_load, :roles => :app, :except => { :no_release => true } do
         capifony_pretty_print "--> Setting up Propel (classes, SQL)"
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:build --insert-sql --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:build --insert-sql #{console_options}'"
         capifony_puts_ok
       end
 
       desc "Generates ACLs models"
       task :acl, :roles => :app, :except => { :no_release => true } do
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:acl:init --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:acl:init #{console_options}'"
       end
 
       desc "Inserts propel ACL tables"
       task :acl_load, :roles => :app, :except => { :no_release => true } do
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:acl:init --env=#{symfony_env_prod} --force'", :once => true
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} propel:acl:init #{console_options} --force'", :once => true
       end
     end
   end

--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -3,7 +3,7 @@ namespace :symfony do
   task :default, :roles => :app, :except => { :no_release => true } do
     prompt_with_default(:task_arguments, "cache:clear")
 
-    stream "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{task_arguments} --env=#{symfony_env_prod}'"
+    stream "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} #{task_arguments} #{console_options}'"
   end
 
 
@@ -46,7 +46,7 @@ namespace :symfony do
         install_options += " --relative"
       end
 
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assets:install #{assets_install_path}#{install_options} --env=#{symfony_env_prod}'"
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assets:install #{assets_install_path}#{install_options} #{console_options}'"
       capifony_puts_ok
     end
   end
@@ -56,7 +56,7 @@ namespace :symfony do
     task :dump, :roles => :app,  :except => { :no_release => true } do
       capifony_pretty_print "--> Dumping all assets to the filesystem"
 
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump --env=#{symfony_env_prod} --no-debug #{latest_release}/#{web_path}'"
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump #{console_options} #{latest_release}/#{web_path}'"
       capifony_puts_ok
     end
   end
@@ -169,7 +169,7 @@ namespace :symfony do
           capifony_pretty_print "--> Warming up cache"
         end
 
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} cache:#{action.to_s} --env=#{symfony_env_prod}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} cache:#{action.to_s} #{console_options}'"
         run "#{try_sudo} chmod -R g+w #{latest_release}/#{cache_path}"
         capifony_puts_ok
       end

--- a/spec/capifony_symfony2_doctrine_spec.rb
+++ b/spec/capifony_symfony2_doctrine_spec.rb
@@ -29,7 +29,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:cache:clear_metadata')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:cache:clear_query" do
@@ -37,7 +37,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:cache:clear_query')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:cache:clear_result" do
@@ -45,7 +45,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:cache:clear_result')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:database tasks" do
@@ -58,7 +58,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:database:create')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:database:create --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:database:create --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:database:drop" do
@@ -66,7 +66,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:database:drop')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:database:drop --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:database:drop --force --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:schema tasks" do
@@ -80,7 +80,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:schema:create')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:create --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:create --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:schema:drop" do
@@ -88,7 +88,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:schema:drop')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:drop --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:drop --force --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:schema:update" do
@@ -96,7 +96,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:schema:update')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:load_fixtures task" do
@@ -108,7 +108,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:load_fixtures')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:migrations tasks" do
@@ -121,7 +121,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:migrations:status')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:migrations:status --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:migrations:status --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:mongodb tasks" do
@@ -137,7 +137,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:mongodb:schema:create')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:create --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:create --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:mongodb:schema:update" do
@@ -145,7 +145,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:mongodb:schema:update')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:update --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:update --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:mongodb:schema:drop" do
@@ -153,7 +153,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:mongodb:schema:drop')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:drop --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:drop --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:mongodb:indexes:create" do
@@ -161,7 +161,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:mongodb:indexes:create')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:create --index --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:create --index --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:mongodb:indexes:drop" do
@@ -169,7 +169,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:mongodb:indexes:drop')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:drop --index --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:mongodb:schema:drop --index --env=prod --no-debug\'') }
   end
 
   it "defines symfony:doctrine:init tasks" do
@@ -181,7 +181,7 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:init:acl')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console init:acl --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console init:acl --env=prod --no-debug\'') }
   end
 
   context "when running symfony:doctrine:* with custom entity manager" do
@@ -198,14 +198,14 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:migrations:status')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:create --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:drop --force --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod --em=custom_em\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:migrations:status --env=prod --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:create --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:drop --force --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:schema:update --force --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:fixtures:load --env=prod --no-debug --em=custom_em\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:migrations:status --env=prod --no-debug --em=custom_em\'') }
   end
   
   context "when running symfony:doctrine:clear_* with flush option" do
@@ -217,9 +217,9 @@ describe "Capifony::Symfony2 - doctrine" do
       @configuration.find_and_execute_task('symfony:doctrine:cache:clear_result')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --flush\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --flush\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --flush\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-metadata --env=prod --no-debug --flush\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-query --env=prod --no-debug --flush\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console doctrine:cache:clear-result --env=prod --no-debug --flush\'') }
   end
 
 end

--- a/spec/capifony_symfony2_propel_spec.rb
+++ b/spec/capifony_symfony2_propel_spec.rb
@@ -26,7 +26,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:database:create')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:database:create --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:database:create --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:database:drop" do
@@ -34,7 +34,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:database:drop')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:database:drop --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:database:drop --env=prod --no-debug\'') }
   end
 
   it "defines symfony:propel:build tasks" do
@@ -51,7 +51,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:model')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:model:build --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:model:build --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:model with old Symfony2 version" do
@@ -60,7 +60,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:model')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-model --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-model --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:model with old dev Symfony2 version" do
@@ -69,7 +69,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:model')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-model --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-model --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql" do
@@ -77,7 +77,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:sql:build --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:sql:build --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql with old Symfony2 version" do
@@ -86,7 +86,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-sql --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-sql --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql with old dev Symfony2 version" do
@@ -95,7 +95,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-sql --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build-sql --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql_load" do
@@ -103,7 +103,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql_load')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:sql:insert --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:sql:insert --force --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql_load with old Symfony2 version" do
@@ -112,7 +112,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql_load')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:insert-sql --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:insert-sql --force --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:sql_load with old dev Symfony2 version" do
@@ -121,7 +121,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:sql_load')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:insert-sql --force --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:insert-sql --force --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:all_and_load" do
@@ -129,7 +129,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:all_and_load')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build --insert-sql --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:build --insert-sql --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:acl" do
@@ -137,7 +137,7 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:acl')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:acl:init --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:acl:init --env=prod --no-debug\'') }
   end
 
   context "when running symfony:propel:build:acl_load" do
@@ -145,6 +145,6 @@ describe "Capifony::Symfony2 - propel" do
       @configuration.find_and_execute_task('symfony:propel:build:acl_load')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:acl:init --env=prod --force\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console propel:acl:init --env=prod --no-debug --force\'') }
   end
 end

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -53,7 +53,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assets:install" do
@@ -62,7 +62,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --symlink --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --symlink --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assets:install" do
@@ -71,7 +71,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --relative --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --relative --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assets:install" do
@@ -81,7 +81,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --symlink --relative --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --symlink --relative --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assets:install with sudo" do
@@ -90,7 +90,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run('sudo sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --env=prod\'') }
+    it { should have_run('sudo sh -c \'cd /var/www/releases/20120927 && php app/console assets:install web --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assets:install with a custom assets_install_path" do
@@ -99,7 +99,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assets:install')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install some/where --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assets:install some/where --env=prod --no-debug\'') }
   end
 
   it "defines symfony:assetic tasks" do
@@ -279,7 +279,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:cache:clear')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console cache:clear --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console cache:clear --env=prod --no-debug\'') }
     it { should have_run(' chmod -R g+w /var/www/releases/20120927/app/cache') }
   end
 
@@ -288,7 +288,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:cache:warmup')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console cache:warmup --env=prod\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console cache:warmup --env=prod --no-debug\'') }
     it { should have_run(' chmod -R g+w /var/www/releases/20120927/app/cache') }
   end
 


### PR DESCRIPTION
Addresses #351

Consolidated the --env=#{symfony_env_prod} code into a console_options function that will optionally include the --no-debug flag, if necessary.

Updated all tests and Symfony2 console commands accordingly.
