### PR TITLE
Remove `--no-scripts` from composer call

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -61,7 +61,7 @@ module Capifony
         set :composer_bin,          false
 
         # Options to pass to composer when installing/updating
-        set :composer_options,      "--no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader"
+        set :composer_options,      "--no-dev --verbose --prefer-dist --optimize-autoloader"
 
         # Whether to update vendors using the configured dependency manager (composer or bin/vendors)
         set :update_vendors,        false
@@ -79,7 +79,6 @@ module Capifony
         set :dump_assetic_assets,   false
 
         # Assets install
-        set :assets_install,        true
         set :assets_symlinks,       false
         set :assets_relative,       false
         set :assets_install_path,   web_path
@@ -284,8 +283,6 @@ module Capifony
             end
           end
 
-          symfony.bootstrap.build
-
           if use_set_permissions
             symfony.deploy.set_permissions
           end
@@ -294,16 +291,8 @@ module Capifony
             symfony.propel.build.model
           end
 
-          if use_composer
-            symfony.composer.dump_autoload
-          end
-
           if update_assets_version
             symfony.assets.update_version   # Update `assets_version`
-          end
-
-          if assets_install
-            symfony.assets.install          # Publish bundle assets
           end
 
           if cache_warmup

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -171,7 +171,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar update --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar update --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:update with a given composer_bin" do
@@ -182,7 +182,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer update --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer update --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:update with enabled copy_vendors" do
@@ -204,7 +204,7 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:install without any existing composer.phar in the previous release" do
@@ -217,7 +217,7 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:install" do
@@ -227,7 +227,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:install with a given composer_bin" do
@@ -238,7 +238,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer install --no-dev --verbose --prefer-dist --optimize-autoloader\'') }
   end
 
   context "when running symfony:composer:install with enabled copy_vendors" do


### PR DESCRIPTION
Before I start changing existing behaviour: What was the reason for `no-scripts` in the composer-call?

```
    # Options to pass to composer when installing/updating
    set :composer_options,      "--no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader"
```

The reason I ask is, that this scripts could be anything and this may be required in further steps. I faced a problem while I tried symfony-cmf/CreateBundle. It make use of composers script-handlers to download a javascript library, which is then used as assets. With capifony this library is missing.
