### PR TITLE
Improvement #112 PostgresqlDB password is passed to pg_dump and psql command

### DIFF
--- a/lib/symfony2/database.rb
+++ b/lib/symfony2/database.rb
@@ -19,7 +19,7 @@ namespace :database do
         data = capture("#{try_sudo} sh -c 'mysqldump -u#{config['database_user']} --host='#{config['database_host']}' --password='#{config['database_password']}' #{config['database_name']} | gzip -c > #{file}'")
         puts data
       when "pdo_pgsql", "pgsql"
-        data = capture("#{try_sudo} sh -c 'pg_dump -U #{config['database_user']} #{config['database_name']} --clean | gzip -c > #{file}'")
+        data = capture("#{try_sudo} sh -c 'PGPASSWORD=\"#{config['database_password']}\" pg_dump -U #{config['database_user']} #{config['database_name']} --clean | gzip -c > #{file}'")
         puts data
       end
 
@@ -51,7 +51,7 @@ namespace :database do
       when "pdo_mysql", "mysql"
         `mysqldump -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} > #{tmpfile}`
       when "pdo_pgsql", "pgsql"
-        `pg_dump -U #{config['database_user']} #{config['database_name']} --clean > #{tmpfile}`
+        `PGPASSWORD=\"#{config['database_password']}\" pg_dump -U #{config['database_user']} #{config['database_name']} --clean > #{tmpfile}`
       end
 
       File.open(tmpfile, "r+") do |f|
@@ -91,7 +91,7 @@ namespace :database do
       when "pdo_mysql", "mysql"
         `mysql -u#{config['database_user']} --password=\"#{config['database_password']}\" #{config['database_name']} < backups/#{sqlfile}`
       when "pdo_pgsql", "pgsql"
-        `psql -U #{config['database_user']} #{config['database_name']} < backups/#{sqlfile}`
+        `PGPASSWORD=\"#{config['database_password']}\" psql -U #{config['database_user']} #{config['database_name']} < backups/#{sqlfile}`
       end
       FileUtils.rm("backups/#{sqlfile}")
     end
@@ -116,7 +116,7 @@ namespace :database do
         data = capture("#{try_sudo} mysql -u#{config['database_user']} --host='#{config['database_host']}' --password='#{config['database_password']}' #{config['database_name']} < #{remote_tmp_dir}/#{sqlfile}")
         puts data
       when "pdo_pgsql", "pgsql"
-        data = capture("#{try_sudo} psql -U #{config['database_user']} #{config['database_name']} < #{remote_tmp_dir}/#{sqlfile}")
+        data = capture("#{try_sudo} PGPASSWORD=\"#{config['database_password']}\" psql -U #{config['database_user']} #{config['database_name']} < #{remote_tmp_dir}/#{sqlfile}")
         puts data
       end
 


### PR DESCRIPTION
Postgresql database usages improvement

Current version did not pass the database password into the <code>pg_dump</code> or the <code>psql</code> command during any of the tasks:

<pre>cap database:dump:local        
cap database:dump:remote                
cap database:move:to_local               
cap database:move:to_remote</pre>


The impact was that password protected postgresql database could not be dumped or moved unless a .pgpass file is used on the remote and local server.
This patch will pass the password into these commands and will no longer needs the usages of a .pgpass file on the remote and local host.

This is an enhancement of the previous issue: https://github.com/everzet/capifony/pull/112 
