### PR TITLE
"interactive_mode" should also affect composer

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -140,14 +140,19 @@ namespace :symfony do
         set :composer_bin, "#{php_bin} composer.phar"
       end
 
+      options = "#{composer_options}"
+      if !interactive_mode
+        options += " --no-interaction"
+      end
+
       if use_composer_tmp
         logger.debug "Installing composer dependencies to #{$temp_destination}"
         capifony_pretty_print "--> Installing Composer dependencies in temp location"
-        run_locally "cd #{$temp_destination} && #{composer_bin} install #{composer_options}"
+        run_locally "cd #{$temp_destination} && #{composer_bin} install #{options}"
         capifony_puts_ok
       else
         capifony_pretty_print "--> Installing Composer dependencies"
-        run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} install #{composer_options}'"
+        run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} install #{options}'"
         capifony_puts_ok
       end
     end
@@ -159,8 +164,13 @@ namespace :symfony do
         set :composer_bin, "#{php_bin} composer.phar"
       end
 
+      options = "#{composer_options}"
+      if !interactive_mode
+        options += " --no-interaction"
+      end
+
       capifony_pretty_print "--> Updating Composer dependencies"
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} update #{composer_options}'"
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} update #{options}'"
       capifony_puts_ok
     end
 

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -174,6 +174,15 @@ describe "Capifony::Symfony2 - symfony" do
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar update --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
+  context "when running symfony:composer:update with interactive_mode disabled" do
+    before do
+      @configuration.set :interactive_mode, false
+      @configuration.find_and_execute_task('symfony:composer:update')
+    end
+
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar update --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction\'') }
+  end
+
   context "when running symfony:composer:update with a given composer_bin" do
     before do
       @configuration.set :composer_bin, "my_composer"
@@ -228,6 +237,15 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
+  end
+
+  context "when running symfony:composer:install with interactive mode disabled" do
+    before do
+      @configuration.set :interactive_mode, false
+      @configuration.find_and_execute_task('symfony:composer:install')
+    end
+
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar install --no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction\'') }
   end
 
   context "when running symfony:composer:install with a given composer_bin" do


### PR DESCRIPTION
If `interactive_mode` is set to `false` capifony should also set `--no-interaction` to the composer options too.

Sidenote: `Symfony/Console`, the console-handler used by composer, ignores multiple appearance of flags, thus if somebody set `--no-interaction` manually and `interactive_mode` to `false` nothing special happens.
