### PR TITLE
Added how to use `copy_vendors` to documentation

### DIFF
--- a/cookbook/speeding-up-deploy.markdown
+++ b/cookbook/speeding-up-deploy.markdown
@@ -5,7 +5,7 @@ title: Speeding up deploy
 
 > As of
 > [2.2.2](https://github.com/everzet/capifony/blob/master/CHANGELOG.md#222--november-13-2012),
-> capifony provides this task. Just add `set :copy_vendors, true` to your deploy.rb file
+> capifony provides this task. To use it, add `set :copy_vendors, true` to your deploy.rb file
 
 With default configuration, capifony will reinstall all your vendors for each deploy.
 If you feel that is inefficient, you can manage to have your vendors just updated, not


### PR DESCRIPTION
It said that this was available in 2.2.2, but not how to use it.
