### PR TITLE
Fix :update_assets_version usage with SVN

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -28,7 +28,7 @@ namespace :symfony do
     task :update_version, :roles => :app, :except => { :no_release => true } do
       capifony_pretty_print "--> Updating assets version (in config.yml)"
 
-      run "#{try_sudo} sed -i 's/\\(assets_version:[ ]*\\)\\([a-zA-Z0-9_]*\\)\\(.*\\)$/\\1#{real_revision[0,7]}\\3/g' #{latest_release}/#{app_config_path}/config.yml"
+      run "#{try_sudo} sed -i 's/\\(assets_version:[ ]*\\)\\([a-zA-Z0-9_]*\\)\\(.*\\)$/\\1#{real_revision.to_s[0,7]}\\3/g' #{latest_release}/#{app_config_path}/config.yml"
       capifony_puts_ok
     end
 


### PR DESCRIPTION
When used with Subversion real_revision is Fixnum so this code fails with:

```
wrong number of arguments (2 for 1) (ArgumentError)
```

This patch fixes it.
