### PR TITLE
human readable timestamp on db backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.3.1 / ???
 
-n/a
+* Changed database backup filename to be human readable
 
 ### 2.3.0 / July 26, 2013
 

--- a/lib/symfony2/database.rb
+++ b/lib/symfony2/database.rb
@@ -6,7 +6,7 @@ namespace :database do
     desc "Dumps remote database"
     task :remote, :roles => :db, :only => { :primary => true } do
       env       = fetch(:deploy_env, "remote")
-      filename  = "#{application}.#{env}_dump.#{Time.now.to_i}.sql.gz"
+      filename  = "#{application}.#{env}_dump.#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.sql.gz"
       file      = "#{remote_tmp_dir}/#{filename}"
       sqlfile   = "#{application}_dump.sql"
       config    = ""
@@ -40,7 +40,7 @@ namespace :database do
 
     desc "Dumps local database"
     task :local do
-      filename  = "#{application}.local_dump.#{Time.now.to_i}.sql.gz"
+      filename  = "#{application}.local_dump.#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.sql.gz"
       tmpfile   = "#{backup_path}/#{application}_dump_tmp.sql"
       file      = "#{backup_path}/#{filename}"
       config    = load_database_config IO.read("#{app_config_path}/#{app_config_file}"), symfony_env_local


### PR DESCRIPTION
Changed the database backup filename generation strategy to now use a human readable format, equal to the one used to generate the releases folders on the servers

https://github.com/everzet/capifony/issues/410
