### PR TITLE
Fix typo in composer-vendors.markdown

### DIFF
--- a/cookbook/composer-vendors.markdown
+++ b/cookbook/composer-vendors.markdown
@@ -42,8 +42,8 @@ specified within the `composer.json` file. This is because the `composer_options
 default is `--no-scripts --no-dev --verbose --prefer-dist --optimize-autoloader`
 
 Some extenal bundles may require a script to run with deployment. If you require
-composer to run scripts you can use the `composer_options` variable to specifiy
-what is included when the composer command is called. For example to run the scripts
+composer to run scripts you can use the `composer_options` variable to specify
+what is included when the composer command is called. For example, to run the scripts
 update the parameter:
 
 {% highlight ruby %}


### PR DESCRIPTION
Fixed the "specifiy" (extra i) typo in the Scripts section and added a comma after "For example".
