### PR TITLE
Add missing backup_path definition for symfony1

### DIFF
--- a/lib/capifony_symfony1.rb
+++ b/lib/capifony_symfony1.rb
@@ -20,6 +20,9 @@ set :shared_files,      %w(config/databases.yml)
 # Asset folders (that need to be timestamped)
 set :asset_children,    %w(web/css web/images web/js)
 
+# Database backup folder
+set :backup_path,           "backups"
+
 # Use ORM
 set :use_orm,           true
 


### PR DESCRIPTION
Make "Custom backup path" work for symfony1.
Broken since this commit:
https://github.com/everzet/capifony/commit/60bbf0431099a06abe1cd21c0b4a955b3c8b9f3b
