### PR TITLE
Shared parameters.yml by default

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -97,7 +97,7 @@ module Capifony
         set :controllers_to_clear, ['app_*.php']
 
         # Files that need to remain the same between deploys
-        set :shared_files,          false
+        set :shared_files,          [app_path + "/config/" + app_config_file]
 
         # Dirs that need to remain the same between deploys (shared dirs)
         set :shared_children,       [log_path, web_path + "/uploads"]


### PR DESCRIPTION
Is there a reason, why the `parameters.yml` isn't shared by default? I had a huge problem setting up a server _without_ the parameters file shared, when I noticed, that it isn't really useful to keep it release-dependent. Also it would allow to think about a builtin solution for the setup, that is currently solved using a custom solution within the deploy script [1], or manually.

Maybe I could try provide a PR, but I'd like to hear some feedback first :smile: 

[1] http://capifony.org/cookbook/upload-parameters-file.html
