### PR TITLE
Enhancement on configuration options

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -67,6 +67,9 @@ module Capifony
         # Options to pass to composer when installing/updating
         set :composer_options,      "--no-dev --verbose --prefer-dist --optimize-autoloader --no-progress"
 
+        # Options to pass to composer when dumping the autoloader (dump-autoloader)
+        set :composer_dump_autoload_options, "--optimize"
+
         # Whether to update vendors using the configured dependency manager (composer or bin/vendors)
         set :update_vendors,        false
 

--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -183,7 +183,7 @@ namespace :symfony do
       end
 
       capifony_pretty_print "--> Dumping an optimized autoloader"
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} dump-autoload --optimize'"
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{composer_bin} dump-autoload #{composer_dump_autoload_options}'"
       capifony_puts_ok
     end
 


### PR DESCRIPTION
I add a new variable to set options for the composer dump-autoload action.
Sometimes it is necessary to set the option for example "--working-dir". 
Extended test for new option.
