### PR TITLE
Copy vendor dir to latest_release, not to latest_release/vendor

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -190,7 +190,7 @@ namespace :symfony do
     task :copy_vendors, :except => { :no_release => true } do
       capifony_pretty_print "--> Copying vendors from previous release"
 
-      run "vendorDir=#{current_path}/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir #{latest_release}/vendor; fi;"
+      run "vendorDir=#{current_path}/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir #{latest_release}; fi;"
       capifony_puts_ok
     end
 


### PR DESCRIPTION
If you do copy it to latest_release/vendor, you will get
latest_release/vendor/vendor
and composer will download all vendors again.

This made me have 20GB of vendors because every version copied the versions of all previous versions resulting in
current/vendor/vendor/vendor/vendor/vendor/.../vendor
with each vendor directory containing all vendors
