### PR TITLE
Fixed error incompatible character encodings: UTF-8 and ASCII-8BIT

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -211,7 +211,7 @@ module Capifony
 
               def write(s)
                 if @@firstLine
-                  s = '✘' << "\n" << s
+                  _write('✘'.red << "\n")  
                   @@firstLine = false
                 end
 


### PR DESCRIPTION
Fixed issue #440 for Ruby version 1.9.3+
