### PR TITLE
Removing unneeded overwrite of assetic `write_to` parameter

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -57,7 +57,7 @@ namespace :symfony do
     task :dump, :roles => :app,  :except => { :no_release => true } do
       capifony_pretty_print "--> Dumping all assets to the filesystem"
 
-      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump #{console_options} #{latest_release}/#{web_path}'"
+      run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} assetic:dump #{console_options}'"
       capifony_puts_ok
     end
   end

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -111,7 +111,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assetic:dump')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assetic:dump --env=prod --no-debug /var/www/releases/20120927/web\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php app/console assetic:dump --env=prod --no-debug\'') }
   end
 
   context "when running symfony:assetic:dump with sudo" do
@@ -120,7 +120,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:assetic:dump')
     end
 
-    it { should have_run('sudo sh -c \'cd /var/www/releases/20120927 && php app/console assetic:dump --env=prod --no-debug /var/www/releases/20120927/web\'') }
+    it { should have_run('sudo sh -c \'cd /var/www/releases/20120927 && php app/console assetic:dump --env=prod --no-debug\'') }
   end
 
   it "defines symfony:vendors tasks" do


### PR DESCRIPTION
Removing unneeded overwrite of assetic `write_to` parameter when dumping assets

fix #450
