### PR TITLE
Move set_permission task after cache warmup

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -294,10 +294,6 @@ module Capifony
             end
           end
 
-          if use_set_permissions
-            symfony.deploy.set_permissions
-          end
-
           if model_manager == "propel"
             symfony.propel.build.model
           end
@@ -329,6 +325,11 @@ module Capifony
               set(:controllers_to_clear) { clear_controllers }
             end
             symfony.project.clear_controllers
+          end
+
+          if use_set_permissions
+            # Set permissions after all cache files have been created
+            symfony.deploy.set_permissions
           end
         end
 


### PR DESCRIPTION
Hello. Is there any reason why `set_permission` is not the last task of the Symfony2 module?

I currently have a problem when using the `:chown` method of `set_permission`, because `cache:warmup` is not done  with `:webserver_user`, then all `app/cache` directory has multiple owners.

This may also fix #443
