### PR TITLE
Recreated composer autoload after deploy:rollback

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -347,6 +347,13 @@ module Capifony
         after "deploy:create_symlink" do
           puts "--> Successfully deployed!".green
         end
+        
+        # Recreate the autoload file after rolling back
+        # https://github.com/everzet/capifony/issues/422
+        after "deploy:rollback" do
+            run "cd #{current_path} && #{composer_bin} dump-autoload #{composer_dump_autoload_options}"
+        end        
+        
       end
 
     end


### PR DESCRIPTION
Most commonly the vendor directory is shared, which makes the class loader file shared as well.
This causes an issue with `cap deploy:rollback` as the class loader is still referencing files from the latest (now deleted) version.

See https://github.com/everzet/capifony/issues/422 for more details.

Not very familiar with Ruby, which is why I'm not sure how to replace the stable version of Capifony with this one to test the new changes. Suggestions?

Thank you.
