### PR TITLE
Moved `cache warmup` task after `assetic dump` task

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -306,16 +306,16 @@ module Capifony
             symfony.assets.update_version   # Update `assets_version`
           end
 
-          if cache_warmup
-            symfony.cache.warmup            # Warmup clean cache
-          end
-
           if assets_install
             symfony.assets.install          # Install assets
           end
 
           if dump_assetic_assets
             symfony.assetic.dump            # Dump assetic assets
+          end
+
+          if cache_warmup
+            symfony.cache.warmup            # Warmup clean cache
           end
 
           if clear_controllers


### PR DESCRIPTION
Using the first deployment strategy, in heavy projects, you may encounter having load of assets and when `assetic:dump` is used and `cache_warmup` is set to `true`, Capifony will warmup the cache before setting the symlink for the newest release thus I moved this task to a lower level 
