### PR TITLE
Missing parameter "-p" for "getfacl" on CentOS

### DIFF
--- a/lib/symfony2/deploy.rb
+++ b/lib/symfony2/deploy.rb
@@ -43,7 +43,7 @@ namespace :deploy do
           dirs.each do |dir|
             is_owner = (capture "`echo stat #{dir} -c %U`").chomp == user
             if is_owner && permission_method != :chown
-              has_facl = (capture "getfacl -p #{dir} | grep #{webserver_user} | wc -l").chomp != "0"
+              has_facl = (capture "getfacl --absolute-names #{dir} | grep #{webserver_user} | wc -l").chomp != "0"
               if (!has_facl)
                 methods[permission_method].each do |cmd|
                   try_sudo sprintf(cmd, dir)


### PR DESCRIPTION
I am trying to deploy to a CentOS system, that has a getfacl command that does not know the "-p" switch, but only the long form of "--absolute-names".

Manpage for the CentOS getfacl:
http://man.flashnux.com/en/centos/5/5.2/man1/getfacl.1.html
