### PR TITLE
Updated the specified version for the ruby-progressbar to 1.4.1 (the lat...

### DIFF
--- a/capifony.gemspec
+++ b/capifony.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colored', ">= 1.2.0"
   spec.add_dependency 'inifile', ">= 2.0.2"
   spec.add_dependency 'capistrano-maintenance', '0.0.3'
-  spec.add_dependency 'ruby-progressbar', '1.0.2'
+  spec.add_dependency 'ruby-progressbar', '1.4.1'
 
   spec.authors      = [ "Konstantin Kudryashov", "William Durand" ]
   spec.email        = [ "ever.zet@gmail.com", "william.durand1@gmail.com" ]


### PR DESCRIPTION
ruby-progressbar 1.0.2 has an issue when installing the rdocs that breaks the installation of capifony using ‘gem install capifony’
see issue and fix here:
https://github.com/jfelchner/ruby-progressbar/issues/26

I've tested both a clean install and my deploy scripts using this change and nothing broke. Let me know if I can provide any more information.
