### PR TITLE
symfony:assets:update_version executed before composer

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -277,6 +277,10 @@ module Capifony
         end
 
         after "deploy:finalize_update" do
+          if update_assets_version
+            symfony.assets.update_version   # Update `assets_version`
+          end
+
           if use_composer && !use_composer_tmp
             if update_vendors
               symfony.composer.update
@@ -300,10 +304,6 @@ module Capifony
 
           if use_composer && !use_composer_tmp
             symfony.composer.dump_autoload
-          end
-
-          if update_assets_version
-            symfony.assets.update_version   # Update `assets_version`
           end
 
           if assets_install


### PR DESCRIPTION
if composer install or update runs scripts (i.e. install:assets), it generates cache (precisely, compiles the container) and the newly set asset version is not taken into account.
