### PR TITLE
removed unneeded dump of autoload files

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -302,10 +302,6 @@ module Capifony
             symfony.propel.build.model
           end
 
-          if use_composer && !use_composer_tmp
-            symfony.composer.dump_autoload
-          end
-
           if assets_install
             symfony.assets.install          # Install assets
           end


### PR DESCRIPTION
This is not needed as the autoload is dumped on every install/ update:
https://github.com/composer/composer/blob/master/src/Composer/Installer.php#L288
