### PR TITLE
Support composer.phar version specify

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -64,6 +64,10 @@ module Capifony
         # If set to false, Capifony will download/install composer
         set :composer_bin,          false
 
+        # Release number to composer
+        # If you would like to instead update to a specific release simply specify it (for example '1.0.0-alpha8')
+        set :composer_version,      ""
+
         # Options to pass to composer when installing/updating
         set :composer_options,      "--no-dev --verbose --prefer-dist --optimize-autoloader --no-progress"
 

--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -112,20 +112,25 @@ namespace :symfony do
   namespace :composer do
     desc "Gets composer and installs it"
     task :get, :roles => :app, :except => { :no_release => true } do
+      install_options = ''
+      unless composer_version.empty?
+        install_options += " -- --version=#{composer_version}"
+      end
+
       if use_composer_tmp
         # Because we always install to temp location we assume that we download composer every time.
         logger.debug "Downloading composer to #{$temp_destination}"
         capifony_pretty_print "--> Downloading Composer to temp location"
-        run_locally "cd #{$temp_destination} && curl -s http://getcomposer.org/installer | #{php_bin}"
+        run_locally "cd #{$temp_destination} && curl -s http://getcomposer.org/installer | #{php_bin}#{install_options}"
       else
         if !remote_file_exists?("#{latest_release}/composer.phar")
           capifony_pretty_print "--> Downloading Composer"
 
-          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}'"
+          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}#{install_options}'"
         else
           capifony_pretty_print "--> Updating Composer"
 
-          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} composer.phar self-update'"
+          run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} composer.phar self-update #{composer_version}'" \
         end
       end
       capifony_puts_ok

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -212,7 +212,21 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
+  end
+
+  context "when running symfony:composer:install with an existing composer.phar in the previous release and given composer_version" do
+    before do
+      @configuration.set :composer_version, "1.0.0-alpha8"
+      @configuration.stub(:remote_file_exists?).and_return(true)
+      @configuration.find_and_execute_task('symfony:composer:install')
+    end
+
+    it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
+    it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update 1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -225,7 +239,7 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -257,6 +271,17 @@ describe "Capifony::Symfony2 - symfony" do
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod my_composer install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
+  end
+
+  context "when running symfony:composer:install with a given composer_version" do
+    before do
+      @configuration.set :composer_version, "1.0.0-alpha8"
+      @configuration.find_and_execute_task('symfony:composer:install')
+    end
+
+    it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
   context "when running symfony:composer:install with enabled copy_vendors" do


### PR DESCRIPTION
Composer's `self-update` & getcomposer's `install` can specific version of composer.phar

Hope to support that :)

(I don't like that the revision of composer.phar may change depending on the time due to the fact that task `composer:get` is called.)
#### References
- [Download Composer](https://getcomposer.org/download/)
- [Documentation 13. self-update](https://getcomposer.org/doc/03-cli.md#self-update)
