### PR TITLE
Rename database move commands to copy.

### DIFF
--- a/lib/symfony1/database.rb
+++ b/lib/symfony1/database.rb
@@ -61,7 +61,7 @@ namespace :database do
     end
   end
 
-  namespace :move do
+  namespace :copy do
     desc "Dump remote database, download it to local & populate here"
     task :to_local, :roles => :db, :only => { :primary => true } do
 

--- a/lib/symfony2/database.rb
+++ b/lib/symfony2/database.rb
@@ -72,7 +72,7 @@ namespace :database do
     end
   end
 
-  namespace :move do
+  namespace :copy do
     desc "Dumps remote database, downloads it to local, and populates here"
     task :to_local, :roles => :db, :only => { :primary => true } do
       env       = fetch(:deploy_env, "remote")


### PR DESCRIPTION
The naming of the database `move` commands is a little confusing because it implies that the remote database won't exist after the move.

I've renamed these to `copy` to better reflect what they do.
