### PR TITLE
Use --tabular for getfacl instead of -t shortcut

### DIFF
--- a/lib/symfony2/deploy.rb
+++ b/lib/symfony2/deploy.rb
@@ -46,7 +46,7 @@ namespace :deploy do
           dirs.each do |dir|
             is_owner = (capture "`echo stat #{dir} -c %U`").chomp == user
             if is_owner && permission_method != :chown
-              has_facl = (capture "getfacl --absolute-names -t #{dir} | grep #{webserver_user}.*rwx | wc -l").chomp != "0"
+              has_facl = (capture "getfacl --absolute-names --tabular #{dir} | grep #{webserver_user}.*rwx | wc -l").chomp != "0"
               if (!has_facl)
                 methods[permission_method].each do |cmd|
                   try_sudo sprintf(cmd, dir)


### PR DESCRIPTION
Hi!

Some systems do not support `-t` shortcut for `getfacl`. Red Hat 5.1 for instance outputs something like this:

``` bash
$ getfacl --help
getfacl 2.2.39 -- get file access control lists
Usage: getfacl [-dRLPvh] file ...
      --access            display the file access control list only
  -d, --default           display the default access control list only
      --omit-header       do not display the comment header
      --all-effective     print all effective rights
      --no-effective      print no effective rights
      --skip-base         skip files that only have the base entries
  -R, --recursive         recurse into subdirectories
  -L, --logical           logical walk, follow symbolic links
  -P  --physical          physical walk, do not follow symbolic links
      --tabular           use tabular output format
      --numeric           print numeric user/group identifiers
      --absolute-names    don't strip leading '/' in pathnames
  -v, --version           print version and exit
  -h, --help              this help text
```

Thus cache permission task fails silently. Changing to full option name i.e. `--tabular` fixes the problem.

Thanks in advance.
