### PR TITLE
Inifile 3.0.0 gem is incompatible with Capifony. Use Inifile version >= ...

### DIFF
--- a/capifony.gemspec
+++ b/capifony.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', ">= 2.13.5","<= 2.16.0"
   spec.add_dependency 'colored', ">= 1.2.0"
-  spec.add_dependency 'inifile', ">= 2.0.2"
+  spec.add_dependency 'inifile', ">= 2.0.2","<3.0.0"
   spec.add_dependency 'capistrano-maintenance', '0.0.3'
   spec.add_dependency 'ruby-progressbar', '1.4.1'
 


### PR DESCRIPTION
...2.0.2 and < 3.0.0. fixes #523
