### PR TITLE
Set default :use_composer to true

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -55,7 +55,7 @@ module Capifony
 
         # Whether to use composer to install vendors.
         # If set to false, it will use the bin/vendors script
-        set :use_composer,          false
+        set :use_composer,          true
 
         # Whether to use composer to install vendors to a local temp directory.
         set :use_composer_tmp,     false


### PR DESCRIPTION
`bin/vendors` has been deprecated a long time ago. Perhaps it's time to disable it by default?
