### PR TITLE
Add compatibility for the Symfony 3 directory structure

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -23,23 +23,35 @@ module Capifony
         load 'symfony2/web'
         load 'symfony2/shared'
 
+        # Whether to use the Symfony 3 directory structure.
+        # Available since Symfony 2.5, the cache and log paths
+        # are `var/cache` and `var/log` and console path is
+        # `bin/console`
+        set :use_symfony_3_dirs,    false
+
         # Symfony application path
         set :app_path,              "app"
 
         # Symfony web path
         set :web_path,              "web"
 
+        # Symfony bin path
+        set :bin_path,              "bin"
+
+        # Symfony var path
+        set :var_path,              "var"
+
         # Symfony console bin
-        set :symfony_console,       app_path + "/console"
+        set :symfony_console,       (use_symfony_3_dirs ? bin_path : app_path) + "/console"
 
         # Symfony debug flag for console commands
         set :symfony_debug,         false
 
         # Symfony log path
-        set :log_path,              app_path + "/logs"
+        set :log_path,              (use_symfony_3_dirs ? var_path : app_path) + "/logs"
 
         # Symfony cache path
-        set :cache_path,            app_path + "/cache"
+        set :cache_path,            (use_symfony_3_dirs ? var_path : app_path) + "/cache"
 
         # Symfony config file path
         set :app_config_path,       app_path + "/config"
@@ -48,10 +60,10 @@ module Capifony
         set :app_config_file,       "parameters.yml"
 
         # Symfony bin vendors
-        set :symfony_vendors,       "bin/vendors"
+        set :symfony_vendors,       bin_path + "/vendors"
 
         # Symfony build_bootstrap script
-        set :build_bootstrap,       "bin/build_bootstrap"
+        set :build_bootstrap,       bin_path + "/build_bootstrap"
 
         # Whether to use composer to install vendors.
         # If set to false, it will use the bin/vendors script

--- a/spec/capifony_symfony2_spec.rb
+++ b/spec/capifony_symfony2_spec.rb
@@ -21,6 +21,7 @@ describe "Capifony::Symfony2" do
   it "defines Symfony2 related variables" do
     @configuration.fetch(:app_path).should == 'app'
     @configuration.fetch(:web_path).should == 'web'
+    @configuration.fetch(:use_symfony_3_dirs).should == false
     @configuration.fetch(:symfony_console).should == 'app/console'
     @configuration.fetch(:log_path).should == 'app/logs'
     @configuration.fetch(:cache_path).should == 'app/cache'
@@ -29,5 +30,25 @@ describe "Capifony::Symfony2" do
     @configuration.fetch(:writable_dirs).should == ['app/logs', 'app/cache']
     @configuration.fetch(:controllers_to_clear).should == ['app_*.php']
   end
+
+  it "defines Symfony3 related variables" do
+    @configuration.set :use_symfony_3_dirs, true
+
+    Capifony::Symfony2.load_into(@configuration)
+
+    @configuration.fetch(:app_path).should == 'app'
+    @configuration.fetch(:web_path).should == 'web'
+    @configuration.fetch(:var_path).should == 'var'
+    @configuration.fetch(:bin_path).should == 'bin'
+    @configuration.fetch(:use_symfony_3_dirs).should == true
+    @configuration.fetch(:symfony_console).should == 'bin/console'
+    @configuration.fetch(:log_path).should == 'var/logs'
+    @configuration.fetch(:cache_path).should == 'var/cache'
+    @configuration.fetch(:shared_children).should == ['var/logs', 'web/uploads']
+    @configuration.fetch(:asset_children).should == ['web/css', 'web/images', 'web/js']
+    @configuration.fetch(:writable_dirs).should == ['var/logs', 'var/cache']
+    @configuration.fetch(:controllers_to_clear).should == ['app_*.php']
+  end
+
 
 end


### PR DESCRIPTION
I've been using this in two new Symfony projects for a couple of months now, one of them is quite large and I haven't had any issues. However, my Ruby skills aren't the best and given this project supports Symfony 1 and Symfony 2, there should probably be a `capifony_symfony3.rb` file also.

So to use it with the new directory structure, you just configure:

```ruby
set :use_symfony_3_dirs, true
```

However in the composer.json for a new Symfony project, there are the options `symfony-var-dir` and `symfony-bin-dir`. If these are customized, then you configure these to match also.

```ruby
set :bin_path, "bin"
set :var_path, "var"
```