### PR TITLE
Revert "Recreated composer autoload after deploy:rollback"

### DIFF
--- a/lib/capifony_symfony2.rb
+++ b/lib/capifony_symfony2.rb
@@ -347,13 +347,6 @@ module Capifony
         after "deploy:create_symlink" do
           puts "--> Successfully deployed!".green
         end
-        
-        # Recreate the autoload file after rolling back
-        # https://github.com/everzet/capifony/issues/422
-        after "deploy:rollback" do
-            run "cd #{current_path} && #{composer_bin} dump-autoload #{composer_dump_autoload_options}"
-        end        
-        
       end
 
     end


### PR DESCRIPTION
This PR fixes #511 by reverting the change introduced in #460. IMHO, it is a bad patch for a problem you shouldn't be having and instead creates lots of other problems:
- The patch introduced in the PR does not work at all if composer_bin is not set - simply because invoking deploy:rollback never invokes `symfony:composer:get` (which sets composer_bin to the correct local path). This is the error #511 is referring to.
- #460 is only an issue if the vendor directory is shared. If it isn't shared, there is always the correct composer autoloader present, so the default deploy:rollback (reverting the symlink, then deleting the "broken" release folder) will work.
- If the vendor directory is shared, the introduced "fix" still isn't guaranteed to work, since it only tries to dump the autoloader but doesn't re-install all composer dependencies (note that a newer release might have introduced an incompatible package or even have removed packages the old version relied on. So without running a complete `composer install` the software would be in a worse state than before.
- Last but not least, sharing the vendor directory is not an option at all when using `use_composer_tmp`, since it would always remove the vendor directory and replace it with a symlink to an (empty) shared vendor directory.

To avoid all these issues, this PR simply reverts the commit. Yes, this will break `deploy:rollback` for everybody who is using a shared vendor directory. On the other hand, this should be discouraged, because of the aforementioned issues. Instead, people should use copy_vendors if they want to speed up deployment.
