### PR TITLE
Changes protocol from composer URL

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -147,12 +147,12 @@ namespace :symfony do
         # Because we always install to temp location we assume that we download composer every time.
         logger.debug "Downloading composer to #{$temp_destination}"
         capifony_pretty_print "--> Downloading Composer to temp location"
-        run_locally "cd #{$temp_destination} && curl -s http://getcomposer.org/installer | #{php_bin}#{install_options}"
+        run_locally "cd #{$temp_destination} && curl -s https://getcomposer.org/installer | #{php_bin}#{install_options}"
       else
         if !remote_file_exists?("#{latest_release}/composer.phar")
           capifony_pretty_print "--> Downloading Composer"
 
-          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s http://getcomposer.org/installer | #{php_bin}#{install_options}'"
+          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -s https://getcomposer.org/installer | #{php_bin}#{install_options}'"
         else
           capifony_pretty_print "--> Updating Composer"
 

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -170,7 +170,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar update --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -190,7 +190,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod my_composer update --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -211,7 +211,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -225,7 +225,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update 1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -238,7 +238,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -249,7 +249,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -269,7 +269,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod my_composer install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -280,7 +280,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -298,7 +298,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar dump-autoload --optimize\'') }
   end
 
@@ -308,7 +308,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s http://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -s https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer dump-autoload --optimize\'') }
   end
 


### PR DESCRIPTION
Composer installation now needs to be done with HTTPS, since doing it using HTTP will return a NGINX response with status 302 like this one:
```
<html>
    <head><title>302 Found</title></head>
    <body bgcolor="white">
      <center><h1>302 Found</h1></center>
      <hr><center>nginx</center>
    </body>
</html>
```

and will not download the installer. By using ```https://getcomposer.org/installer``` the installation will occur just fine.

This fix issue #516 