### PR TITLE
Add -L to curl options for follow 3XX response codes

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -147,12 +147,12 @@ namespace :symfony do
         # Because we always install to temp location we assume that we download composer every time.
         logger.debug "Downloading composer to #{$temp_destination}"
         capifony_pretty_print "--> Downloading Composer to temp location"
-        run_locally "cd #{$temp_destination} && curl -sS https://getcomposer.org/installer | #{php_bin}#{install_options}"
+        run_locally "cd #{$temp_destination} && curl -sSL https://getcomposer.org/installer | #{php_bin}#{install_options}"
       else
         if !remote_file_exists?("#{latest_release}/composer.phar")
           capifony_pretty_print "--> Downloading Composer"
 
-          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -sS https://getcomposer.org/installer | #{php_bin}#{install_options}'"
+          run "#{try_sudo} sh -c 'cd #{latest_release} && curl -sSL https://getcomposer.org/installer | #{php_bin}#{install_options}'"
         else
           capifony_pretty_print "--> Updating Composer"
 

--- a/spec/capifony_symfony2_symfony_spec.rb
+++ b/spec/capifony_symfony2_symfony_spec.rb
@@ -170,7 +170,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar update --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -190,7 +190,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod my_composer update --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -211,7 +211,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -225,7 +225,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update 1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -238,7 +238,7 @@ describe "Capifony::Symfony2 - symfony" do
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
     it { should_not have_run(' sh -c \'cp /var/www/releases/20120920/composer.phar /var/www/releases/20120927/\'') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar self-update \'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
@@ -249,7 +249,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -269,7 +269,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927/vendor; fi;') }
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod my_composer install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -280,7 +280,7 @@ describe "Capifony::Symfony2 - symfony" do
     end
 
     it { should_not have_run('vendorDir=/var/www/current/vendor; if [ -d $vendorDir ] || [ -h $vendorDir ]; then cp -a $vendorDir /var/www/releases/20120927; fi;') }
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php -- --version=1.0.0-alpha8\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && SYMFONY_ENV=prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress\'') }
   end
 
@@ -298,7 +298,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && php composer.phar dump-autoload --optimize\'') }
   end
 
@@ -308,7 +308,7 @@ describe "Capifony::Symfony2 - symfony" do
       @configuration.find_and_execute_task('symfony:composer:dump_autoload')
     end
 
-    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sS https://getcomposer.org/installer | php\'') }
+    it { should_not have_run(' sh -c \'cd /var/www/releases/20120927 && curl -sSL https://getcomposer.org/installer | php\'') }
     it { should have_run(' sh -c \'cd /var/www/releases/20120927 && my_composer dump-autoload --optimize\'') }
   end
 


### PR DESCRIPTION
Based in comment https://github.com/everzet/capifony/pull/568#issuecomment-96520198 for improve more PR #568 

As curl man page http://curl.haxx.se/docs/manpage.html says:

	-L, --location

	(HTTP/HTTPS) If the server reports that the requested page has moved to a different location (indicated with a Location: header and a 3XX response code), this option will make curl redo the request on the new place. If used together with -i, --include or -I, --head, headers from all requested pages will be shown. When authentication is used, curl only sends its credentials to the initial host. If a redirect takes curl to a different host, it won't be able to intercept the user+password. See also --location-trusted on how to change this. You can limit the amount of redirects to follow by using the --max-redirs option.

	When curl follows a redirect and the request is not a plain GET (for example POST or PUT), it will do the following request with a GET if the HTTP response was 301, 302, or 303. If the response code was any other 3xx code, curl will re-send the following request using the same unmodified method.

	You can tell curl to not change the non-GET request method to GET after a 30x response by using the dedicated options for that: --post301, --post302 and -post303.

I create this patch running in master:

    sed -i "s@curl -sS https://getcomposer.org@curl -sSL https://getcomposer.org@g" lib/symfony2/symfony.rb

This is important in future if they decide change some behaviour again redirecting (like composer previously they did).