### PR TITLE
Fixed typo for assets version update task

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -38,7 +38,7 @@ namespace :symfony do
         puts "    Latest assets version: (#{assets_version})"
 
         file_path = "#{latest_release}/#{app_config_path}/assets_version.yml"
-        file_content = "parameters:\n    assets_version: #{assets_version}"
+        file_content = "parameters:\\n    assets_version: #{assets_version}"
         run "echo '#{file_content}' | #{try_sudo} tee #{file_path}"
         capifony_puts_ok
       end


### PR DESCRIPTION
Hi, i propose this fix because with:

```
file_content = "parameters:\n    assets_version: #{assets_version}"
```

capifony ran:

```
echo 'parameters:\\\n    assets_version: nyop6h' |  tee /path/to/app/config/assets_version.yml
```

with a resulting error for symfony yaml parser in the assets_version file.
