### PR TITLE
Fixed typo for assets version update task

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -39,7 +39,7 @@ namespace :symfony do
 
         file_path = "#{latest_release}/#{app_config_path}/assets_version.yml"
         file_content = "parameters:\n    assets_version: #{assets_version}"
-        run "echo '#{file_content}' | #{try_sudo} tee #{file_path}"
+        run "echo -e '#{file_content}' | #{try_sudo} tee #{file_path}"
         capifony_puts_ok
       end
     end


### PR DESCRIPTION
The `symfony:assets:update_version` task creates a file with content:

```
parameters:\
    assets_version: o19f9r
```

After the changes in the code:

```
parameters:
    assets_version: o19f9r
```
