### PR TITLE
Work around ruby / bash newline backslash issue

### DIFF
--- a/lib/symfony2/symfony.rb
+++ b/lib/symfony2/symfony.rb
@@ -39,7 +39,7 @@ namespace :symfony do
 
         file_path = "#{latest_release}/#{app_config_path}/assets_version.yml"
         file_content = "parameters:\n    assets_version: #{assets_version}"
-        run "echo '#{file_content}' | #{try_sudo} tee #{file_path}"
+        run "printf 'parameters:\\n    assets_version: #{assets_version}' | #{try_sudo} tee #{file_path}"
         capifony_puts_ok
       end
     end


### PR DESCRIPTION
When interpolating strings like so:

```
file_content = "parameters:\n    assets_version: #{assets_version}"
run "echo '#{file_content}' | #{try_sudo} tee #{file_path}"
```

I end up with a file on my server looking like:

```
parameters:\
    assets_version: o2aepl
```

This println "fix" is helping
