### PR TITLE
webiste is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ lot easier.
 
 ## What's next? ##
 
-Read the [capifony documentation](http://capifony.org/)
+Read the <del>[capifony documentation](http://capifony.org/)</del>
 
 ## Running the test suite ##
 


### PR DESCRIPTION
Maybe you could move the content previously hosted on capifony.org website on the wiki? Alternate solution: a github hosted site